### PR TITLE
feat(cli): add rm subcommand

### DIFF
--- a/packages/cli/src/command/rm.ts
+++ b/packages/cli/src/command/rm.ts
@@ -1,0 +1,8 @@
+import { Effect } from "effect";
+import { Command } from "effect/unstable/cli";
+
+export const createRm = Command.make("rm", {}, () =>
+  Effect.gen(function* () {
+    console.log("rm");
+  }),
+);

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -8,9 +8,10 @@ import {
   BunTerminal,
 } from "@effect/platform-bun";
 import { createNew } from "./command/new";
+import { createRm } from "./command/rm";
 
 const command = Command.make("skipper").pipe(
-  Command.withSubcommands([createNew]),
+  Command.withSubcommands([createNew, createRm]),
 );
 
 // Set up the CLI application


### PR DESCRIPTION
### Motivation
- Add a new `rm` CLI subcommand so the CLI can expose a removal command surface for future implementation and testing.

### Description
- Introduced `packages/cli/src/command/rm.ts` which exports `createRm` and currently logs `rm` when invoked.
- Registered the new subcommand in the root CLI by importing `createRm` and adding it to `Command.withSubcommands` in `packages/cli/src/index.ts`.

### Testing
- Ran `bun x tsc -p packages/cli/tsconfig.json --noEmit` which completed successfully. 
- Attempted `bun packages/cli/src/index.ts rm` which failed at runtime due to an existing `effect` module export mismatch in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69a2c691bc888326ae8ead0031ce91a8)