### PR TITLE
feat: extract hello command into dedicated module with tests

### DIFF
--- a/src/app/register-commands.ts
+++ b/src/app/register-commands.ts
@@ -4,6 +4,7 @@ import { registerAddCommand } from "../command/a.js";
 import { registerRemoveCommand } from "../command/rm.js";
 import { registerRunCommand } from "../command/run.js";
 import { registerAwsCommand } from "../command/aws/index.js";
+import { registerHelloCommand } from "../command/hello.js";
 
 /**
  * Register all skipper commands.
@@ -18,20 +19,4 @@ export function registerCommands(program: Command): void {
   registerRemoveCommand(program);
   registerRunCommand(program);
   registerAwsCommand(program);
-}
-
-/**
- * Register simple health command.
- *
- * @since 1.0.0
- * @category CLI
- */
-function registerHelloCommand(program: Command): void {
-  program
-    .command("hello")
-    .description("Say hello")
-    .argument("[name]", "name to greet")
-    .action((name) => {
-      console.log(`Hello ${name || "World"}!`);
-    });
 }

--- a/src/command/hello.test.ts
+++ b/src/command/hello.test.ts
@@ -1,0 +1,10 @@
+import { expect, test } from "bun:test";
+import { buildGreeting } from "./hello.js";
+
+test("buildGreeting returns default greeting without name", () => {
+  expect(buildGreeting()).toBe("Hello World!");
+});
+
+test("buildGreeting returns personalised greeting with name", () => {
+  expect(buildGreeting("Alice")).toBe("Hello Alice!");
+});

--- a/src/command/hello.ts
+++ b/src/command/hello.ts
@@ -1,0 +1,27 @@
+import type { Command } from "commander";
+
+/**
+ * Build greeting message for given name.
+ *
+ * @since 1.0.0
+ * @category CLI
+ */
+export function buildGreeting(name?: string): string {
+  return `Hello ${name || "World"}!`;
+}
+
+/**
+ * Register hello command.
+ *
+ * @since 1.0.0
+ * @category CLI
+ */
+export function registerHelloCommand(program: Command): void {
+  program
+    .command("hello")
+    .description("Say hello")
+    .argument("[name]", "name to greet")
+    .action((name) => {
+      console.log(buildGreeting(name));
+    });
+}


### PR DESCRIPTION
## Summary

Closes #36

### What this PR does

- Extracts the `hello` command from `register-commands.ts` into a dedicated `src/command/hello.ts` module
- Exposes a pure `buildGreeting(name?)` helper that formats the greeting string
- Adds `src/command/hello.test.ts` with two unit tests covering the default and personalised greeting paths
- Updates `register-commands.ts` to import and call `registerHelloCommand` from the new module

### Scope

This is a single, self-contained PR. No follow-up PRs are needed.

### Line count (non-lockfile)

| File | Added | Deleted |
|---|---|---|
| `src/command/hello.ts` | 27 | 0 |
| `src/command/hello.test.ts` | 10 | 0 |
| `src/app/register-commands.ts` | 1 | 16 |
| **Total** | **38** | **16** |

Total changed lines: **54** (well within the 200-line limit).