### PR TITLE
add --force flag to skipper rm

### DIFF
--- a/.changeset/wet-llamas-travel.md
+++ b/.changeset/wet-llamas-travel.md
@@ -1,0 +1,5 @@
+---
+"@skippercorp/skipper": patch
+---
+
+add `--force` flag to `skipper rm` to remove dirty worktrees

--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ Skipper manages:
 | --- | --- |
 | `skipper clone <owner/repo-or-url>` | Clones repo using `gh` into `~/.local/share/github` |
 | `skipper a` | Selects repo/worktree with `fzf`, creates if missing, then attaches tmux |
-| `skipper rm` | Removes selected worktree and kills matching tmux session |
+| `skipper rm [--force]` | Removes selected worktree and kills matching tmux session (`--force` discards local worktree changes) |
 | `skipper run "<prompt>"` | Selects repo, pulls latest, runs `opencode run` |
 | `skipper aws bootstrap ...` | Deploys shared AWS ingress stack + optional GitHub webhook |
 | `skipper aws deploy ...` | Deploys repository-scoped subscription stack |


### PR DESCRIPTION
## Summary
- add `-f`/`--force` option to `skipper rm`
- pass force flag through remove flow to run `git worktree remove --force` when requested
- add release changeset and README command docs update