### PR TITLE
fix rm force dirty worktree removal

### DIFF
--- a/.changeset/giant-kings-help.md
+++ b/.changeset/giant-kings-help.md
@@ -1,0 +1,5 @@
+---
+"@skippercorp/skipper": patch
+---
+
+force `sk rm` to remove dirty worktrees via `git worktree remove --force`

--- a/src/command/rm.test.ts
+++ b/src/command/rm.test.ts
@@ -1,0 +1,19 @@
+import { expect, test } from "bun:test";
+import { formatRemoveGitWorktreeError } from "./rm.js";
+
+test("rm uses forced git worktree remove", async () => {
+  const source = await Bun.file(new URL("./rm.ts", import.meta.url)).text();
+  expect(source).toContain("worktree remove --force");
+});
+
+test("formatRemoveGitWorktreeError prefers stderr", () => {
+  expect(formatRemoveGitWorktreeError(" fatal: dirty worktree \n", 128)).toBe(
+    "fatal: dirty worktree",
+  );
+});
+
+test("formatRemoveGitWorktreeError falls back to exit code", () => {
+  expect(formatRemoveGitWorktreeError("", 17)).toBe(
+    "git worktree remove failed with code 17",
+  );
+});

--- a/src/command/rm.ts
+++ b/src/command/rm.ts
@@ -36,7 +36,7 @@ export function registerRemoveCommand(program: Command): void {
  * @category Worktree
  */
 async function runRemoveCommand(options: RemoveCommandOptions = {}): Promise<void> {
-  const force = options.force === true;
+  const force = options.force ?? true;
   const worktreeBaseDir = `${process.env.HOME}/.local/share/skipper/worktree`;
   const allWorktrees = await collectWorktrees(worktreeBaseDir);
   assertNonEmpty(allWorktrees, "No worktrees found");
@@ -121,10 +121,26 @@ async function removeGitWorktree(
     ? await Bun.$`git -C ${repoPath} worktree remove --force ${worktreePath}`.nothrow()
     : await Bun.$`git -C ${repoPath} worktree remove ${worktreePath}`.nothrow();
   if (result.exitCode === 0) return;
-  const stderr = result.stderr.toString().trim();
   const command = force ? "git worktree remove --force" : "git worktree remove";
-  const fallback = `${command} failed with code ${result.exitCode}`;
-  throw new Error(stderr || fallback);
+  throw new Error(
+    formatRemoveGitWorktreeError(result.stderr.toString(), result.exitCode, command),
+  );
+}
+
+/**
+ * Build remove-git-worktree error message.
+ *
+ * @since 1.0.1
+ * @category Worktree
+ */
+export function formatRemoveGitWorktreeError(
+  stderr: string,
+  exitCode: number,
+  command = "git worktree remove",
+): string {
+  const trimmed = stderr.trim();
+  if (trimmed.length > 0) return trimmed;
+  return `${command} failed with code ${exitCode}`;
 }
 
 /**


### PR DESCRIPTION
## Summary
- force `sk rm` to call `git worktree remove --force`, so dirty worktrees can be removed
- keep existing rm flow and cleanup behavior, with shared error-message formatter
- add patch changeset and rm-focused tests

## Testing
- bun test src/command/rm.test.ts