### PR TITLE
add local worktree dashboard ui

### DIFF
--- a/.changeset/green-falcons-draw.md
+++ b/.changeset/green-falcons-draw.md
@@ -1,0 +1,6 @@
+---
+"@skippercorp/skipper": minor
+---
+
+Add a local `skipper ui` dashboard command to manage worktrees (checkout, run prompt, remove, refresh) from one TUI screen.
+Refactor worktree lifecycle logic into a shared service used by `a`, `rm`, `run`, and the new UI command.

--- a/README.md
+++ b/README.md
@@ -83,9 +83,28 @@ Skipper manages:
 | `skipper a` | Selects repo/worktree with `fzf`, creates if missing, then attaches tmux |
 | `skipper rm [--force]` | Removes selected worktree and kills matching tmux session (`--force` discards local worktree changes) |
 | `skipper run "<prompt>"` | Selects repo, pulls latest, runs `opencode run` |
+| `skipper ui` | Opens a single worktree list with checkout/run/remove actions |
 | `skipper aws bootstrap ...` | Deploys shared AWS ingress stack + optional GitHub webhook |
 | `skipper aws deploy ...` | Deploys repository-scoped subscription stack |
 | `skipper aws run "<prompt>"` | Starts ECS task from bootstrap stack for prompt execution |
+
+### Local dashboard UI
+
+Open local dashboard:
+
+```bash
+skipper ui
+```
+
+Controls:
+
+- `Enter` checkout selected worktree
+- `p` run prompt in selected repo
+- `d` remove selected worktree (with confirmation)
+- `r` refresh state
+- `q` quit
+
+Note: `skipper ui` requires an interactive terminal (TTY).
 
 ## AWS worker flow
 

--- a/bun.lock
+++ b/bun.lock
@@ -12,6 +12,7 @@
         "@aws-sdk/client-sts": "^3.1000.0",
         "@octokit/webhooks": "^13.7.1",
         "@octokit/webhooks-types": "^7.6.1",
+        "@opentui/core": "^0.1.84",
         "@pulumi/aws": "^7.20.0",
         "@pulumi/pulumi": "^3.120.0",
         "commander": "^14.0.3",
@@ -156,6 +157,8 @@
 
     "@changesets/write": ["@changesets/write@0.4.0", "", { "dependencies": { "@changesets/types": "^6.1.0", "fs-extra": "^7.0.1", "human-id": "^4.1.1", "prettier": "^2.7.1" } }, "sha512-CdTLvIOPiCNuH71pyDu3rA+Q0n65cmAbXnwWH84rKGiFumFzkmHNT8KHTMEchcxN+Kl8I54xGUhJ7l3E7X396Q=="],
 
+    "@dimforge/rapier2d-simd-compat": ["@dimforge/rapier2d-simd-compat@0.17.3", "", {}, "sha512-bijvwWz6NHsNj5e5i1vtd3dU2pDhthSaTUZSh14DUGGKJfw8eMnlWZsxwHBxB/a3AXVNDjL9abuHw1k9FGR+jg=="],
+
     "@gar/promise-retry": ["@gar/promise-retry@1.0.2", "", { "dependencies": { "retry": "^0.13.1" } }, "sha512-Lm/ZLhDZcBECta3TmCQSngiQykFdfw+QtI1/GYMsZd4l3nG+P8WLB16XuS7WaBGLQ+9E+cOcWQsth9cayuGt8g=="],
 
     "@grpc/grpc-js": ["@grpc/grpc-js@1.14.3", "", { "dependencies": { "@grpc/proto-loader": "^0.8.0", "@js-sdsl/ordered-map": "^4.4.2" } }, "sha512-Iq8QQQ/7X3Sac15oB6p0FmUg/klxQvXLeileoqrTRGJYLV+/9tubbr9ipz0GKHjmXVsgFPo/+W+2cA8eNcR+XA=="],
@@ -167,6 +170,62 @@
     "@isaacs/fs-minipass": ["@isaacs/fs-minipass@4.0.1", "", { "dependencies": { "minipass": "^7.0.4" } }, "sha512-wgm9Ehl2jpeqP3zw/7mo3kRHFp5MEDhqAdwy1fTGkHAwnkGOVsgpvQhL8B5n1qlb01jV3n/bI0ZfZp5lWA1k4w=="],
 
     "@isaacs/string-locale-compare": ["@isaacs/string-locale-compare@1.1.0", "", {}, "sha512-SQ7Kzhh9+D+ZW9MA0zkYv3VXhIDNx+LzM6EJ+/65I3QY+enU6Itte7E5XX7EWrqLW2FN4n06GWzBnPoC3th2aQ=="],
+
+    "@jimp/core": ["@jimp/core@1.6.0", "", { "dependencies": { "@jimp/file-ops": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "await-to-js": "^3.0.0", "exif-parser": "^0.1.12", "file-type": "^16.0.0", "mime": "3" } }, "sha512-EQQlKU3s9QfdJqiSrZWNTxBs3rKXgO2W+GxNXDtwchF3a4IqxDheFX1ti+Env9hdJXDiYLp2jTRjlxhPthsk8w=="],
+
+    "@jimp/diff": ["@jimp/diff@1.6.0", "", { "dependencies": { "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "pixelmatch": "^5.3.0" } }, "sha512-+yUAQ5gvRC5D1WHYxjBHZI7JBRusGGSLf8AmPRPCenTzh4PA+wZ1xv2+cYqQwTfQHU5tXYOhA0xDytfHUf1Zyw=="],
+
+    "@jimp/file-ops": ["@jimp/file-ops@1.6.0", "", {}, "sha512-Dx/bVDmgnRe1AlniRpCKrGRm5YvGmUwbDzt+MAkgmLGf+jvBT75hmMEZ003n9HQI/aPnm/YKnXjg/hOpzNCpHQ=="],
+
+    "@jimp/js-bmp": ["@jimp/js-bmp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "bmp-ts": "^1.0.9" } }, "sha512-FU6Q5PC/e3yzLyBDXupR3SnL3htU7S3KEs4e6rjDP6gNEOXRFsWs6YD3hXuXd50jd8ummy+q2WSwuGkr8wi+Gw=="],
+
+    "@jimp/js-gif": ["@jimp/js-gif@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "gifwrap": "^0.10.1", "omggif": "^1.0.10" } }, "sha512-N9CZPHOrJTsAUoWkWZstLPpwT5AwJ0wge+47+ix3++SdSL/H2QzyMqxbcDYNFe4MoI5MIhATfb0/dl/wmX221g=="],
+
+    "@jimp/js-jpeg": ["@jimp/js-jpeg@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "jpeg-js": "^0.4.4" } }, "sha512-6vgFDqeusblf5Pok6B2DUiMXplH8RhIKAryj1yn+007SIAQ0khM1Uptxmpku/0MfbClx2r7pnJv9gWpAEJdMVA=="],
+
+    "@jimp/js-png": ["@jimp/js-png@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "pngjs": "^7.0.0" } }, "sha512-AbQHScy3hDDgMRNfG0tPjL88AV6qKAILGReIa3ATpW5QFjBKpisvUaOqhzJ7Reic1oawx3Riyv152gaPfqsBVg=="],
+
+    "@jimp/js-tiff": ["@jimp/js-tiff@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "utif2": "^4.1.0" } }, "sha512-zhReR8/7KO+adijj3h0ZQUOiun3mXUv79zYEAKvE0O+rP7EhgtKvWJOZfRzdZSNv0Pu1rKtgM72qgtwe2tFvyw=="],
+
+    "@jimp/plugin-blit": ["@jimp/plugin-blit@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-M+uRWl1csi7qilnSK8uxK4RJMSuVeBiO1AY0+7APnfUbQNZm6hCe0CCFv1Iyw1D/Dhb8ph8fQgm5mwM0eSxgVA=="],
+
+    "@jimp/plugin-blur": ["@jimp/plugin-blur@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-zrM7iic1OTwUCb0g/rN5y+UnmdEsT3IfuCXCJJNs8SZzP0MkZ1eTvuwK9ZidCuMo4+J3xkzCidRwYXB5CyGZTw=="],
+
+    "@jimp/plugin-circle": ["@jimp/plugin-circle@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-xt1Gp+LtdMKAXfDp3HNaG30SPZW6AQ7dtAtTnoRKorRi+5yCJjKqXRgkewS5bvj8DEh87Ko1ydJfzqS3P2tdWw=="],
+
+    "@jimp/plugin-color": ["@jimp/plugin-color@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "tinycolor2": "^1.6.0", "zod": "^3.23.8" } }, "sha512-J5q8IVCpkBsxIXM+45XOXTrsyfblyMZg3a9eAo0P7VPH4+CrvyNQwaYatbAIamSIN1YzxmO3DkIZXzRjFSz1SA=="],
+
+    "@jimp/plugin-contain": ["@jimp/plugin-contain@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-oN/n+Vdq/Qg9bB4yOBOxtY9IPAtEfES8J1n9Ddx+XhGBYT1/QTU/JYkGaAkIGoPnyYvmLEDqMz2SGihqlpqfzQ=="],
+
+    "@jimp/plugin-cover": ["@jimp/plugin-cover@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-Iow0h6yqSC269YUJ8HC3Q/MpCi2V55sMlbkkTTx4zPvd8mWZlC0ykrNDeAy9IJegrQ7v5E99rJwmQu25lygKLA=="],
+
+    "@jimp/plugin-crop": ["@jimp/plugin-crop@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-KqZkEhvs+21USdySCUDI+GFa393eDIzbi1smBqkUPTE+pRwSWMAf01D5OC3ZWB+xZsNla93BDS9iCkLHA8wang=="],
+
+    "@jimp/plugin-displace": ["@jimp/plugin-displace@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-4Y10X9qwr5F+Bo5ME356XSACEF55485j5nGdiyJ9hYzjQP9nGgxNJaZ4SAOqpd+k5sFaIeD7SQ0Occ26uIng5Q=="],
+
+    "@jimp/plugin-dither": ["@jimp/plugin-dither@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0" } }, "sha512-600d1RxY0pKwgyU0tgMahLNKsqEcxGdbgXadCiVCoGd6V6glyCvkNrnnwC0n5aJ56Htkj88PToSdF88tNVZEEQ=="],
+
+    "@jimp/plugin-fisheye": ["@jimp/plugin-fisheye@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-E5QHKWSCBFtpgZarlmN3Q6+rTQxjirFqo44ohoTjzYVrDI6B6beXNnPIThJgPr0Y9GwfzgyarKvQuQuqCnnfbA=="],
+
+    "@jimp/plugin-flip": ["@jimp/plugin-flip@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-/+rJVDuBIVOgwoyVkBjUFHtP+wmW0r+r5OQ2GpatQofToPVbJw1DdYWXlwviSx7hvixTWLKVgRWQ5Dw862emDg=="],
+
+    "@jimp/plugin-hash": ["@jimp/plugin-hash@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "any-base": "^1.1.0" } }, "sha512-wWzl0kTpDJgYVbZdajTf+4NBSKvmI3bRI8q6EH9CVeIHps9VWVsUvEyb7rpbcwVLWYuzDtP2R0lTT6WeBNQH9Q=="],
+
+    "@jimp/plugin-mask": ["@jimp/plugin-mask@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-Cwy7ExSJMZszvkad8NV8o/Z92X2kFUFM8mcDAhNVxU0Q6tA0op2UKRJY51eoK8r6eds/qak3FQkXakvNabdLnA=="],
+
+    "@jimp/plugin-print": ["@jimp/plugin-print@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/types": "1.6.0", "parse-bmfont-ascii": "^1.0.6", "parse-bmfont-binary": "^1.0.6", "parse-bmfont-xml": "^1.1.6", "simple-xml-to-json": "^1.2.2", "zod": "^3.23.8" } }, "sha512-zarTIJi8fjoGMSI/M3Xh5yY9T65p03XJmPsuNet19K/Q7mwRU6EV2pfj+28++2PV2NJ+htDF5uecAlnGyxFN2A=="],
+
+    "@jimp/plugin-quantize": ["@jimp/plugin-quantize@1.6.0", "", { "dependencies": { "image-q": "^4.0.0", "zod": "^3.23.8" } }, "sha512-EmzZ/s9StYQwbpG6rUGBCisc3f64JIhSH+ncTJd+iFGtGo0YvSeMdAd+zqgiHpfZoOL54dNavZNjF4otK+mvlg=="],
+
+    "@jimp/plugin-resize": ["@jimp/plugin-resize@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/types": "1.6.0", "zod": "^3.23.8" } }, "sha512-uSUD1mqXN9i1SGSz5ov3keRZ7S9L32/mAQG08wUwZiEi5FpbV0K8A8l1zkazAIZi9IJzLlTauRNU41Mi8IF9fA=="],
+
+    "@jimp/plugin-rotate": ["@jimp/plugin-rotate@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-JagdjBLnUZGSG4xjCLkIpQOZZ3Mjbg8aGCCi4G69qR+OjNpOeGI7N2EQlfK/WE8BEHOW5vdjSyglNqcYbQBWRw=="],
+
+    "@jimp/plugin-threshold": ["@jimp/plugin-threshold@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0", "zod": "^3.23.8" } }, "sha512-M59m5dzLoHOVWdM41O8z9SyySzcDn43xHseOH0HavjsfQsT56GGCC4QzU1banJidbUrePhzoEdS42uFE8Fei8w=="],
+
+    "@jimp/types": ["@jimp/types@1.6.0", "", { "dependencies": { "zod": "^3.23.8" } }, "sha512-7UfRsiKo5GZTAATxm2qQ7jqmUXP0DxTArztllTcYdyw6Xi5oT4RaoXynVtCD4UyLK5gJgkZJcwonoijrhYFKfg=="],
+
+    "@jimp/utils": ["@jimp/utils@1.6.0", "", { "dependencies": { "@jimp/types": "1.6.0", "tinycolor2": "^1.6.0" } }, "sha512-gqFTGEosKbOkYF/WFj26jMHOI5OH2jeP1MmC/zbK6BF6VJBf8rIC5898dPfSzZEbSA0wbbV5slbntWVc5PKLFA=="],
 
     "@js-sdsl/ordered-map": ["@js-sdsl/ordered-map@4.4.2", "", {}, "sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw=="],
 
@@ -249,6 +308,20 @@
     "@opentelemetry/sdk-trace-node": ["@opentelemetry/sdk-trace-node@1.30.1", "", { "dependencies": { "@opentelemetry/context-async-hooks": "1.30.1", "@opentelemetry/core": "1.30.1", "@opentelemetry/propagator-b3": "1.30.1", "@opentelemetry/propagator-jaeger": "1.30.1", "@opentelemetry/sdk-trace-base": "1.30.1", "semver": "^7.5.2" }, "peerDependencies": { "@opentelemetry/api": ">=1.0.0 <1.10.0" } }, "sha512-cBjYOINt1JxXdpw1e5MlHmFRc5fgj4GW/86vsKFxJCJ8AL4PdVtYH41gWwl4qd4uQjqEL1oJVrXkSy5cnduAnQ=="],
 
     "@opentelemetry/semantic-conventions": ["@opentelemetry/semantic-conventions@1.28.0", "", {}, "sha512-lp4qAiMTD4sNWW4DbKLBkfiMZ4jbAboJIGOQr5DvciMRI494OapieI9qiODpOt0XBr1LjIDy1xAGAnVs5supTA=="],
+
+    "@opentui/core": ["@opentui/core@0.1.84", "", { "dependencies": { "bun-ffi-structs": "0.1.2", "diff": "8.0.2", "jimp": "1.6.0", "marked": "17.0.1", "yoga-layout": "3.2.1" }, "optionalDependencies": { "@dimforge/rapier2d-simd-compat": "^0.17.3", "@opentui/core-darwin-arm64": "0.1.84", "@opentui/core-darwin-x64": "0.1.84", "@opentui/core-linux-arm64": "0.1.84", "@opentui/core-linux-x64": "0.1.84", "@opentui/core-win32-arm64": "0.1.84", "@opentui/core-win32-x64": "0.1.84", "bun-webgpu": "0.1.5", "planck": "^1.4.2", "three": "0.177.0" }, "peerDependencies": { "web-tree-sitter": "0.25.10" } }, "sha512-UdPD/sldUSiIu588l45lQq6q09zLW8L4GOgkA4E3fyExIlIgOrpIhFSKqZwbVCbe53dQOybHVUdKob64Xxhm4w=="],
+
+    "@opentui/core-darwin-arm64": ["@opentui/core-darwin-arm64@0.1.84", "", { "os": "darwin", "cpu": "arm64" }, "sha512-MpLdRYd2zLJP7IcWHu1SYXFet6ZfOzTUW12iaexlUL4DkAU+P5mO1v/OdLlZrmXVj/FD3BqDM5SUIXNE0+A46Q=="],
+
+    "@opentui/core-darwin-x64": ["@opentui/core-darwin-x64@0.1.84", "", { "os": "darwin", "cpu": "x64" }, "sha512-eEFzEdo/WVVjbpwY2pnQBxkpqsWyGLHNv3kFc0RHvZ3ARIW2qb/Jqo9O9uUbR6th7H77V1NRJ0a6gvby48Oofg=="],
+
+    "@opentui/core-linux-arm64": ["@opentui/core-linux-arm64@0.1.84", "", { "os": "linux", "cpu": "arm64" }, "sha512-AYfG9iLWavfVYZYbNfEZkCimqk8Uq8EzvHKwRkbP24XVZO7eALztZ6PWl2nJqDrw+rYBVSJg0uS6ON+M7NxyBA=="],
+
+    "@opentui/core-linux-x64": ["@opentui/core-linux-x64@0.1.84", "", { "os": "linux", "cpu": "x64" }, "sha512-pLi3a3rqs1BMeCqj1GZm/Qi3zdwilQxaPEI/IeWc5qdzWInpGPHs3uadPJBAllEGRzvTmStMWI6iY6bdc98bng=="],
+
+    "@opentui/core-win32-arm64": ["@opentui/core-win32-arm64@0.1.84", "", { "os": "win32", "cpu": "arm64" }, "sha512-dcQruw9VyYACxukoB+iv8SskQxl5MMeY73uqvQ17dsnM2sfukT+c2MSgbgYImCKKixtlGXLcb5Weo36lQqI5AQ=="],
+
+    "@opentui/core-win32-x64": ["@opentui/core-win32-x64@0.1.84", "", { "os": "win32", "cpu": "x64" }, "sha512-KiCaIVtVnZYQza+vAW8TDbUMxBgd2thvjNOIJ03NmjMiiRnfmO55wA3Zh9vNuQ5PJEYI0awzXYFAZ7kaMsDQxA=="],
 
     "@protobufjs/aspromise": ["@protobufjs/aspromise@1.1.2", "", {}, "sha512-j+gKExEuLmKwvz3OgROXtrJ2UG2x8Ch2YZUxahh+s1F2HZ+wAceUNLkvy6zKCPVRkU++ZWQrdxsUeQXmcg4uoQ=="],
 
@@ -392,6 +465,8 @@
 
     "@szmarczak/http-timer": ["@szmarczak/http-timer@4.0.6", "", { "dependencies": { "defer-to-connect": "^2.0.0" } }, "sha512-4BAffykYOgO+5nzBWYwE3W90sBgLJoUPRWWcL8wlyiM8IB8ipJz3UMJ9KXQd1RKQXpKp8Tutn80HZtWsu2u76w=="],
 
+    "@tokenizer/token": ["@tokenizer/token@0.3.0", "", {}, "sha512-OvjF+z51L3ov0OyAU0duzsYuvO01PH7x4t6DJx+guahgTnBHkhJdG7soQeTSFLWN3efnHyibZ4Z8l2EuWwJN3A=="],
+
     "@tufjs/canonical-json": ["@tufjs/canonical-json@2.0.0", "", {}, "sha512-yVtV8zsdo8qFHe+/3kw81dSLyF7D576A5cCFCi4X7B39tWT7SekaEFUnvnWJHz+9qO7qJTah1JbrDjWKqFtdWA=="],
 
     "@tufjs/models": ["@tufjs/models@4.1.0", "", { "dependencies": { "@tufjs/canonical-json": "2.0.0", "minimatch": "^10.1.1" } }, "sha512-Y8cK9aggNRsqJVaKUlEYs4s7CvQ1b1ta2DVPyAimb0I2qhzjNk+A+mxvll/klL0RlfuIUei8BF7YWiua4kQqww=="],
@@ -416,7 +491,11 @@
 
     "@types/tmp": ["@types/tmp@0.2.6", "", {}, "sha512-chhaNf2oKHlRkDGt+tiKE2Z5aJ6qalm7Z9rlLdBwmOiAAf09YQvvoLXjWK4HWPF1xU/fqvMgfNfpVoBscA/tKA=="],
 
+    "@webgpu/types": ["@webgpu/types@0.1.69", "", {}, "sha512-RPmm6kgRbI8e98zSD3RVACvnuktIja5+yLgDAkTmxLr90BEwdTXRQWNLF3ETTTyH/8mKhznZuN5AveXYFEsMGQ=="],
+
     "abbrev": ["abbrev@4.0.0", "", {}, "sha512-a1wflyaL0tHtJSmLSOVybYhy22vRih4eduhhrkcjgrWGnRfrZtovJ2FRjxuTtkkj47O/baf0R86QU5OuYpz8fA=="],
+
+    "abort-controller": ["abort-controller@3.0.0", "", { "dependencies": { "event-target-shim": "^5.0.0" } }, "sha512-h8lQ8tacZYnR3vNQTgibj+tODHI5/+l06Au2Pcriv/Gmet0eaj4TwWH41sO9wnHDiQsEj19q0drzdWdeAHtweg=="],
 
     "acorn": ["acorn@8.16.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-UVJyE9MttOsBQIDKw1skb9nAwQuR5wuGD3+82K6JgJlm/Y+KI92oNsMNGZCYdDsVtRHSak0pcV5Dno5+4jh9sw=="],
 
@@ -430,15 +509,23 @@
 
     "ansi-styles": ["ansi-styles@4.3.0", "", { "dependencies": { "color-convert": "^2.0.1" } }, "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg=="],
 
+    "any-base": ["any-base@1.1.0", "", {}, "sha512-uMgjozySS8adZZYePpaWs8cxB9/kdzmpX6SgJZ+wbz1K5eYk5QMYDVJaZKhxyIHUdnnJkfR7SVgStgH7LkGUyg=="],
+
     "argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "array-union": ["array-union@2.1.0", "", {}, "sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw=="],
 
+    "await-to-js": ["await-to-js@3.0.0", "", {}, "sha512-zJAaP9zxTcvTHRlejau3ZOY4V7SRpiByf3/dxx2uyKxxor19tpmpV2QRsTKikckwhaPmr2dVpxxMr7jOCYVp5g=="],
+
     "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "base64-js": ["base64-js@1.5.1", "", {}, "sha512-AKpaYlHn8t4SVbOHCy+b5+KKgvR4vrsD8vbvrbiQJps7fKDTkjkDry6ji0rUJjC0kzbNePLwzxq8iypo41qeWA=="],
 
     "better-path-resolve": ["better-path-resolve@1.0.0", "", { "dependencies": { "is-windows": "^1.0.0" } }, "sha512-pbnl5XzGBdrFU/wT4jqmJVPn2B6UHPBOhzMQkY/SPUPB6QtUXtmBHBIwCbXJol93mOpGMnQyP/+BB19q04xj7g=="],
 
     "bin-links": ["bin-links@6.0.0", "", { "dependencies": { "cmd-shim": "^8.0.0", "npm-normalize-package-bin": "^5.0.0", "proc-log": "^6.0.0", "read-cmd-shim": "^6.0.0", "write-file-atomic": "^7.0.0" } }, "sha512-X4CiKlcV2GjnCMwnKAfbVWpHa++65th9TuzAEYtZoATiOE2DQKhSp4CJlyLoTqdhBKlXjpXjCTYPNNFS33Fi6w=="],
+
+    "bmp-ts": ["bmp-ts@1.0.9", "", {}, "sha512-cTEHk2jLrPyi+12M3dhpEbnnPOsaZuq7C45ylbbQIiWgDFZq4UVYPEY5mlqjvsj/6gJv9qX5sa+ebDzLXT28Vw=="],
 
     "bowser": ["bowser@2.14.1", "", {}, "sha512-tzPjzCxygAKWFOJP011oxFHs57HzIhOEracIgAePE4pqB3LikALKnSzUyU4MGs9/iCEUuHlAJTjTc5M+u7YEGg=="],
 
@@ -446,9 +533,23 @@
 
     "braces": ["braces@3.0.3", "", { "dependencies": { "fill-range": "^7.1.1" } }, "sha512-yQbXgO/OSZVD2IsiLlro+7Hf6Q18EJrKSEsdoMzKePKXct3gvD8oLcOQdIzGupr5Fj+EDe8gO/lxc1BzfMpxvA=="],
 
+    "buffer": ["buffer@6.0.3", "", { "dependencies": { "base64-js": "^1.3.1", "ieee754": "^1.2.1" } }, "sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA=="],
+
     "buffer-from": ["buffer-from@1.1.2", "", {}, "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ=="],
 
+    "bun-ffi-structs": ["bun-ffi-structs@0.1.2", "", { "peerDependencies": { "typescript": "^5" } }, "sha512-Lh1oQAYHDcnesJauieA4UNkWGXY9hYck7OA5IaRwE3Bp6K2F2pJSNYqq+hIy7P3uOvo3km3oxS8304g5gDMl/w=="],
+
     "bun-types": ["bun-types@1.3.9", "", { "dependencies": { "@types/node": "*" } }, "sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg=="],
+
+    "bun-webgpu": ["bun-webgpu@0.1.5", "", { "dependencies": { "@webgpu/types": "^0.1.60" }, "optionalDependencies": { "bun-webgpu-darwin-arm64": "^0.1.5", "bun-webgpu-darwin-x64": "^0.1.5", "bun-webgpu-linux-x64": "^0.1.5", "bun-webgpu-win32-x64": "^0.1.5" } }, "sha512-91/K6S5whZKX7CWAm9AylhyKrLGRz6BUiiPiM/kXadSnD4rffljCD/q9cNFftm5YXhx4MvLqw33yEilxogJvwA=="],
+
+    "bun-webgpu-darwin-arm64": ["bun-webgpu-darwin-arm64@0.1.5", "", { "os": "darwin", "cpu": "arm64" }, "sha512-qM7W5IaFpWYGPDcNiQ8DOng3noQ97gxpH2MFH1mGsdKwI0T4oy++egSh5Z7s6AQx8WKgc9GzAsTUM4KZkFdacw=="],
+
+    "bun-webgpu-darwin-x64": ["bun-webgpu-darwin-x64@0.1.5", "", { "os": "darwin", "cpu": "x64" }, "sha512-oVoIsme27pcXB68YxnQSAgdNGCa4A3PGWYIBUewOh9VnJaoik4JenGb5Yy+svGE+ETFhQXV9nhHqgMPsDRrO6A=="],
+
+    "bun-webgpu-linux-x64": ["bun-webgpu-linux-x64@0.1.5", "", { "os": "linux", "cpu": "x64" }, "sha512-+SYt09k+xDEl/GfcU7L1zdNgm7IlvAFKV5Xl/auBwuprKG5UwXNhjRlRAWfhTMCUZWN+NDf8E+ZQx0cQi9K2/g=="],
+
+    "bun-webgpu-win32-x64": ["bun-webgpu-win32-x64@0.1.5", "", { "os": "win32", "cpu": "x64" }, "sha512-zvnUl4EAsQbKsmZVu+lEJcH8axQ7MiCfqg2OmnHd6uw1THABmHaX0GbpKiHshdgadNN2Nf+4zDyTJB5YMcAdrA=="],
 
     "cacache": ["cacache@20.0.3", "", { "dependencies": { "@npmcli/fs": "^5.0.0", "fs-minipass": "^3.0.0", "glob": "^13.0.0", "lru-cache": "^11.1.0", "minipass": "^7.0.3", "minipass-collect": "^2.0.1", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "p-map": "^7.0.2", "ssri": "^13.0.0", "unique-filename": "^5.0.0" } }, "sha512-3pUp4e8hv07k1QlijZu6Kn7c9+ZpWWk4j3F8N3xPuCExULobqJydKYOTj1FTq58srkJsXvO7LbGAH4C0ZU3WGw=="],
 
@@ -490,6 +591,8 @@
 
     "detect-indent": ["detect-indent@6.1.0", "", {}, "sha512-reYkTUJAZb9gUuZ2RvVCNhVHdg62RHnJ7WJl8ftMi4diZ6NWlciOzQN88pUhSELEwflJht4oQDv0F0BMlwaYtA=="],
 
+    "diff": ["diff@8.0.2", "", {}, "sha512-sSuxWU5j5SR9QQji/o2qMvqRNYRDOcBTgsJ/DeCf4iSN4gW+gNMXM7wFIP+fdXZxoNiAnHUTGjCr+TSWXdRDKg=="],
+
     "dir-glob": ["dir-glob@3.0.1", "", { "dependencies": { "path-type": "^4.0.0" } }, "sha512-WkrWp9GR4KXfKGYzOLmTuGVi1UWFfws377n9cc55/tb6DuqyF6pcQ5AbiHEshaDpY9v6oaSr2XCDidGmMwdzIA=="],
 
     "emoji-regex": ["emoji-regex@8.0.0", "", {}, "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="],
@@ -506,7 +609,13 @@
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
+    "event-target-shim": ["event-target-shim@5.0.1", "", {}, "sha512-i/2XbnSz/uxRCU6+NdVJgKWDTM427+MqYbkQzD321DuCQJUqOuJKIA0IM2+W2xtYHdKOmZ4dR6fExsd4SXL+WQ=="],
+
+    "events": ["events@3.3.0", "", {}, "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q=="],
+
     "execa": ["execa@5.1.1", "", { "dependencies": { "cross-spawn": "^7.0.3", "get-stream": "^6.0.0", "human-signals": "^2.1.0", "is-stream": "^2.0.0", "merge-stream": "^2.0.0", "npm-run-path": "^4.0.1", "onetime": "^5.1.2", "signal-exit": "^3.0.3", "strip-final-newline": "^2.0.0" } }, "sha512-8uSpZZocAZRBAPIEINJj3Lo9HyGitllczc27Eh5YYojjMFMn8yHMDMaUHE2Jqfq05D/wucwI4JGURyXt1vchyg=="],
+
+    "exif-parser": ["exif-parser@0.1.12", "", {}, "sha512-c2bQfLNbMzLPmzQuOr8fy0csy84WmwnER81W88DzTp9CYNPJ6yzOj2EZAh9pywYpqHnshVLHQJ8WzldAyfY+Iw=="],
 
     "exponential-backoff": ["exponential-backoff@3.1.3", "", {}, "sha512-ZgEeZXj30q+I0EN+CbSSpIyPaJ5HVQD18Z1m+u1FXbAeT94mr1zw50q4q6jiiC447Nl/YTcIYSAftiGqetwXCA=="],
 
@@ -519,6 +628,8 @@
     "fastq": ["fastq@1.20.1", "", { "dependencies": { "reusify": "^1.0.4" } }, "sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw=="],
 
     "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-type": ["file-type@16.5.4", "", { "dependencies": { "readable-web-to-node-stream": "^3.0.0", "strtok3": "^6.2.4", "token-types": "^4.1.1" } }, "sha512-/yFHK0aGjFEgDJjEKP0pWCplsPFPhwyfwevf/pVxiN0tmE4L9LmwWxWukdJSHdoCli4VgQLehjJtwQBnqmsKcw=="],
 
     "fill-range": ["fill-range@7.1.1", "", { "dependencies": { "to-regex-range": "^5.0.1" } }, "sha512-YsGpe3WHLK8ZYi4tWDg2Jy3ebRz2rXowDxnld4bkQB00cc/1Zw9AWnC0i9ztDJitivtQvaI9KaLyKrc+hBW0yg=="],
 
@@ -535,6 +646,8 @@
     "get-caller-file": ["get-caller-file@2.0.5", "", {}, "sha512-DyFP3BM/3YHTQOCUL/w0OZHR0lpKeGrxotcHWcqNEdnltqFwXVfhEBQ94eIo34AfQpo0rGki4cyIiftY06h2Fg=="],
 
     "get-stream": ["get-stream@6.0.1", "", {}, "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg=="],
+
+    "gifwrap": ["gifwrap@0.10.1", "", { "dependencies": { "image-q": "^4.0.0", "omggif": "^1.0.10" } }, "sha512-2760b1vpJHNmLzZ/ubTtNnEx5WApN/PYWJvXvgS+tL1egTTthayFYIQQNi136FLEDcN/IyEY2EcGpIITD6eYUw=="],
 
     "glob": ["glob@13.0.6", "", { "dependencies": { "minimatch": "^10.2.2", "minipass": "^7.1.3", "path-scurry": "^2.0.2" } }, "sha512-Wjlyrolmm8uDpm/ogGyXZXb1Z+Ca2B8NbJwqBVg0axK9GbBeoS7yGV6vjXnYdGm6X53iehEuxxbyiKp8QmN4Vw=="],
 
@@ -566,9 +679,13 @@
 
     "iconv-lite": ["iconv-lite@0.7.2", "", { "dependencies": { "safer-buffer": ">= 2.1.2 < 3.0.0" } }, "sha512-im9DjEDQ55s9fL4EYzOAv0yMqmMBSZp6G0VvFyTMPKWxiSBHUj9NW/qqLmXUwXrrM7AvqSlTCfvqRb0cM8yYqw=="],
 
+    "ieee754": ["ieee754@1.2.1", "", {}, "sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA=="],
+
     "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
 
     "ignore-walk": ["ignore-walk@8.0.0", "", { "dependencies": { "minimatch": "^10.0.3" } }, "sha512-FCeMZT4NiRQGh+YkeKMtWrOmBgWjHjMJ26WQWrRQyoyzqevdaGSakUaJW5xQYmjLlUVk2qUnCjYVBax9EKKg8A=="],
+
+    "image-q": ["image-q@4.0.0", "", { "dependencies": { "@types/node": "16.9.1" } }, "sha512-PfJGVgIfKQJuq3s0tTDOKtztksibuUEbJQIYT3by6wctQo+Rdlh7ef4evJ5NCdxY4CfMbvFkocEwbl4BF8RlJw=="],
 
     "import-in-the-middle": ["import-in-the-middle@1.15.0", "", { "dependencies": { "acorn": "^8.14.0", "acorn-import-attributes": "^1.9.5", "cjs-module-lexer": "^1.2.2", "module-details-from-path": "^1.0.3" } }, "sha512-bpQy+CrsRmYmoPMAE/0G33iwRqwW4ouqdRg8jgbH3aKuCtOc8lxgmYXg2dMM92CRiGP660EtBcymH/eVUpCSaA=="],
 
@@ -595,6 +712,10 @@
     "is-windows": ["is-windows@1.0.2", "", {}, "sha512-eXK1UInq2bPmjyX6e3VHIzMLobc4J94i4AWn+Hpq3OU5KkrRC96OAcR3PRJ/pGu6m8TRnBHP9dkXQVsT/COVIA=="],
 
     "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
+    "jimp": ["jimp@1.6.0", "", { "dependencies": { "@jimp/core": "1.6.0", "@jimp/diff": "1.6.0", "@jimp/js-bmp": "1.6.0", "@jimp/js-gif": "1.6.0", "@jimp/js-jpeg": "1.6.0", "@jimp/js-png": "1.6.0", "@jimp/js-tiff": "1.6.0", "@jimp/plugin-blit": "1.6.0", "@jimp/plugin-blur": "1.6.0", "@jimp/plugin-circle": "1.6.0", "@jimp/plugin-color": "1.6.0", "@jimp/plugin-contain": "1.6.0", "@jimp/plugin-cover": "1.6.0", "@jimp/plugin-crop": "1.6.0", "@jimp/plugin-displace": "1.6.0", "@jimp/plugin-dither": "1.6.0", "@jimp/plugin-fisheye": "1.6.0", "@jimp/plugin-flip": "1.6.0", "@jimp/plugin-hash": "1.6.0", "@jimp/plugin-mask": "1.6.0", "@jimp/plugin-print": "1.6.0", "@jimp/plugin-quantize": "1.6.0", "@jimp/plugin-resize": "1.6.0", "@jimp/plugin-rotate": "1.6.0", "@jimp/plugin-threshold": "1.6.0", "@jimp/types": "1.6.0", "@jimp/utils": "1.6.0" } }, "sha512-YcwCHw1kiqEeI5xRpDlPPBGL2EOpBKLwO4yIBJcXWHPj5PnA5urGq0jbyhM5KoNpypQ6VboSoxc9D8HyfvngSg=="],
+
+    "jpeg-js": ["jpeg-js@0.4.4", "", {}, "sha512-WZzeDOEtTOBK4Mdsar0IqEU5sMr3vSV2RqkAIzUEV2BHnUfKGyswWFPFwK5EeDo93K3FohSHbLAjj0s1Wzd+dg=="],
 
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
@@ -627,6 +748,8 @@
     "lru-cache": ["lru-cache@11.2.6", "", {}, "sha512-ESL2CrkS/2wTPfuend7Zhkzo2u0daGJ/A2VucJOgQ/C48S/zB8MMeMHSGKYpXhIjbPxfuezITkaBH1wqv00DDQ=="],
 
     "make-fetch-happen": ["make-fetch-happen@15.0.4", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/agent": "^4.0.0", "cacache": "^20.0.1", "http-cache-semantics": "^4.1.1", "minipass": "^7.0.2", "minipass-fetch": "^5.0.0", "minipass-flush": "^1.0.5", "minipass-pipeline": "^1.2.4", "negotiator": "^1.0.0", "proc-log": "^6.0.0", "ssri": "^13.0.0" } }, "sha512-vM2sG+wbVeVGYcCm16mM3d5fuem9oC28n436HjsGO3LcxoTI8LNVa4rwZDn3f76+cWyT4GGJDxjTYU1I2nr6zw=="],
+
+    "marked": ["marked@17.0.1", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-boeBdiS0ghpWcSwoNm/jJBwdpFaMnZWRzjA6SkUMYb40SVaN1x7mmfGKp0jvexGcx+7y2La5zRZsYFZI6Qpypg=="],
 
     "merge-stream": ["merge-stream@2.0.0", "", {}, "sha512-abv/qOcuPfk3URPfDzmZU1LKmuw8kT+0nIHvKrKgFrwifol/doWcdA4ZqsWQ8ENrFKkd67Mfpo/LovbIUsbt3w=="],
 
@@ -690,6 +813,8 @@
 
     "npm-run-path": ["npm-run-path@4.0.1", "", { "dependencies": { "path-key": "^3.0.0" } }, "sha512-S48WzZW777zhNIrn7gxOlISNAqi9ZC/uQFnRdbeIHhZhCA6UqpkOT8T1G7BvfdgP4Er8gF4sUbaS0i7QvIfCWw=="],
 
+    "omggif": ["omggif@1.0.10", "", {}, "sha512-LMJTtvgc/nugXj0Vcrrs68Mn2D1r0zf630VNtqtpI1FEO7e+O9FP4gqs9AcnBaSEeoHIPm28u6qgPR0oyEpGSw=="],
+
     "once": ["once@1.4.0", "", { "dependencies": { "wrappy": "1" } }, "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w=="],
 
     "onetime": ["onetime@5.1.2", "", { "dependencies": { "mimic-fn": "^2.1.0" } }, "sha512-kbpaSSGJTWdAY5KPVeMOKXSrPtr8C8C7wodJbcsd51jRnmD+GZu8Y0VoU6Dm5Z4vWr0Ig/1NKuWRKf7j5aaYSg=="],
@@ -714,6 +839,14 @@
 
     "pacote": ["pacote@21.4.0", "", { "dependencies": { "@gar/promise-retry": "^1.0.0", "@npmcli/git": "^7.0.0", "@npmcli/installed-package-contents": "^4.0.0", "@npmcli/package-json": "^7.0.0", "@npmcli/promise-spawn": "^9.0.0", "@npmcli/run-script": "^10.0.0", "cacache": "^20.0.0", "fs-minipass": "^3.0.0", "minipass": "^7.0.2", "npm-package-arg": "^13.0.0", "npm-packlist": "^10.0.1", "npm-pick-manifest": "^11.0.1", "npm-registry-fetch": "^19.0.0", "proc-log": "^6.0.0", "sigstore": "^4.0.0", "ssri": "^13.0.0", "tar": "^7.4.3" }, "bin": { "pacote": "bin/index.js" } }, "sha512-DR7mn7HUOomAX1BORnpYy678qVIidbvOojkBscqy27dRKN+s/hLeQT1MeYYrx1Cxh62jyKjiWiDV7RTTqB+ZEQ=="],
 
+    "pako": ["pako@1.0.11", "", {}, "sha512-4hLB8Py4zZce5s4yd9XzopqwVv/yGNhV1Bl8NTmCq1763HeK2+EwVTv+leGeL13Dnh2wfbqowVPXCIO0z4taYw=="],
+
+    "parse-bmfont-ascii": ["parse-bmfont-ascii@1.0.6", "", {}, "sha512-U4RrVsUFCleIOBsIGYOMKjn9PavsGOXxbvYGtMOEfnId0SVNsgehXh1DxUdVPLoxd5mvcEtvmKs2Mmf0Mpa1ZA=="],
+
+    "parse-bmfont-binary": ["parse-bmfont-binary@1.0.6", "", {}, "sha512-GxmsRea0wdGdYthjuUeWTMWPqm2+FAd4GI8vCvhgJsFnoGhTrLhXDDupwTo7rXVAgaLIGoVHDZS9p/5XbSqeWA=="],
+
+    "parse-bmfont-xml": ["parse-bmfont-xml@1.1.6", "", { "dependencies": { "xml-parse-from-string": "^1.0.0", "xml2js": "^0.5.0" } }, "sha512-0cEliVMZEhrFDwMh4SxIyVJpqYoOWDJ9P895tFuS+XuNzI5UBmBk5U5O4KuJdTnZpSBI4LFA2+ZiJaiwfSwlMA=="],
+
     "parse-conflict-json": ["parse-conflict-json@5.0.1", "", { "dependencies": { "json-parse-even-better-errors": "^5.0.0", "just-diff": "^6.0.0", "just-diff-apply": "^5.2.0" } }, "sha512-ZHEmNKMq1wyJXNwLxyHnluPfRAFSIliBvbK/UiOceROt4Xh9Pz0fq49NytIaeaCUf5VR86hwQ/34FCcNU5/LKQ=="],
 
     "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
@@ -726,17 +859,27 @@
 
     "path-type": ["path-type@4.0.0", "", {}, "sha512-gDKb8aZMDeD/tZWs9P6+q0J9Mwkdl6xMV8TjnGP3qJVJ06bdMgkbBlLU8IdfOsIsFz2BW1rNVT3XuNEl8zPAvw=="],
 
+    "peek-readable": ["peek-readable@4.1.0", "", {}, "sha512-ZI3LnwUv5nOGbQzD9c2iDG6toheuXSZP5esSHBjopsXH4dg19soufvpUGA3uohi5anFtGb2lhAVdHzH6R/Evvg=="],
+
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
     "picomatch": ["picomatch@3.0.1", "", {}, "sha512-I3EurrIQMlRc9IaAZnqRR044Phh2DXY+55o7uJ0V+hYZAcQYSuFWsc9q5PvyDHUSCe1Qxn/iBz+78s86zWnGag=="],
 
     "pify": ["pify@4.0.1", "", {}, "sha512-uB80kBFb/tfd68bVleG9T5GGsGPjJrLAUpR5PZIrhBnIaRTQRjqdJSsIKkOP6OAIFbj7GOrcudc5pNjZ+geV2g=="],
 
+    "pixelmatch": ["pixelmatch@5.3.0", "", { "dependencies": { "pngjs": "^6.0.0" }, "bin": { "pixelmatch": "bin/pixelmatch" } }, "sha512-o8mkY4E/+LNUf6LzX96ht6k6CEDi65k9G2rjMtBe9Oo+VPKSvl+0GKHuH/AlG+GA5LPG/i5hrekkxUc3s2HU+Q=="],
+
+    "planck": ["planck@1.4.3", "", { "peerDependencies": { "stage-js": "^1.0.0-alpha.12" } }, "sha512-B+lHKhRSeg7vZOfEyEzyQVu7nx8JHcX3QgnAcHXrPW0j04XYKX5eXSiUrxH2Z5QR8OoqvjD6zKIaPMdMYAd0uA=="],
+
+    "pngjs": ["pngjs@7.0.0", "", {}, "sha512-LKWqWJRhstyYo9pGvgor/ivk2w94eSjE3RGVuzLGlr3NmD8bf7RcYGze1mNdEHRP6TRP6rMuDHk5t44hnTRyow=="],
+
     "postcss-selector-parser": ["postcss-selector-parser@7.1.1", "", { "dependencies": { "cssesc": "^3.0.0", "util-deprecate": "^1.0.2" } }, "sha512-orRsuYpJVw8LdAwqqLykBj9ecS5/cRHlI5+nvTo8LcCKmzDmqVORXtOIYEEQuL9D4BxtA1lm5isAqzQZCoQ6Eg=="],
 
     "prettier": ["prettier@2.8.8", "", { "bin": { "prettier": "bin-prettier.js" } }, "sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q=="],
 
     "proc-log": ["proc-log@6.1.0", "", {}, "sha512-iG+GYldRf2BQ0UDUAd6JQ/RwzaQy6mXmsk/IzlYyal4A4SNFw54MeH4/tLkF4I5WoWG9SQwuqWzS99jaFQHBuQ=="],
+
+    "process": ["process@0.11.10", "", {}, "sha512-cdGef/drWFoydD1JsMzuFf8100nZl+GT+yacc2bEced5f9Rjk4z+WtFUTBu9PhOi9j/jfmBPu0mMEY4wIdAF8A=="],
 
     "proggy": ["proggy@4.0.0", "", {}, "sha512-MbA4R+WQT76ZBm/5JUpV9yqcJt92175+Y0Bodg3HgiXzrmKu7Ggq+bpn6y6wHH+gN9NcyKn3yg1+d47VaKwNAQ=="],
 
@@ -760,6 +903,10 @@
 
     "read-yaml-file": ["read-yaml-file@1.1.0", "", { "dependencies": { "graceful-fs": "^4.1.5", "js-yaml": "^3.6.1", "pify": "^4.0.1", "strip-bom": "^3.0.0" } }, "sha512-VIMnQi/Z4HT2Fxuwg5KrY174U1VdUIASQVWXXyqtNRtxSr9IYkn1rsI6Tb6HsrHCmB7gVpNwX6JxPTHcH6IoTA=="],
 
+    "readable-stream": ["readable-stream@4.7.0", "", { "dependencies": { "abort-controller": "^3.0.0", "buffer": "^6.0.3", "events": "^3.3.0", "process": "^0.11.10", "string_decoder": "^1.3.0" } }, "sha512-oIGGmcpTLwPga8Bn6/Z75SVaH1z5dUut2ibSyAMVhmUggWpmDn2dapB0n7f8nwaSiRtepAsfJyfXIO5DCVAODg=="],
+
+    "readable-web-to-node-stream": ["readable-web-to-node-stream@3.0.4", "", { "dependencies": { "readable-stream": "^4.7.0" } }, "sha512-9nX56alTf5bwXQ3ZDipHJhusu9NTQJ/CVPtb/XHAJCXihZeitfJvIRS4GqQ/mfIoOE3IelHMrpayVrosdHBuLw=="],
+
     "require-directory": ["require-directory@2.1.1", "", {}, "sha512-fGxEI7+wsG9xrvdjsrlmL22OMTTiHRwAMroiEeMgq8gzoLC/PQr7RsRDSTLUg/bZAZtF+TVIkHc6/4RIKrui+Q=="],
 
     "require-from-string": ["require-from-string@2.0.2", "", {}, "sha512-Xf0nWe6RseziFMu+Ap9biiUbmplq6S9/p+7w7YXP/JBHhrUDDUhwa+vANyubuqfZWTveU//DYVGsDG7RKL/vEw=="],
@@ -780,7 +927,11 @@
 
     "run-parallel": ["run-parallel@1.2.0", "", { "dependencies": { "queue-microtask": "^1.2.2" } }, "sha512-5l4VyZR86LZ/lDxZTR6jqL8AFE2S0IFLMP26AbjsLVADxHdhB/c0GUsH+y39UfCi3dzz8OlQuPmnaJOMoDHQBA=="],
 
+    "safe-buffer": ["safe-buffer@5.2.1", "", {}, "sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ=="],
+
     "safer-buffer": ["safer-buffer@2.1.2", "", {}, "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg=="],
+
+    "sax": ["sax@1.5.0", "", {}, "sha512-21IYA3Q5cQf089Z6tgaUTr7lDAyzoTPx5HRtbhsME8Udispad8dC/+sziTNugOEx54ilvatQ9YCzl4KQLPcRHA=="],
 
     "semver": ["semver@7.7.4", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA=="],
 
@@ -793,6 +944,8 @@
     "signal-exit": ["signal-exit@4.1.0", "", {}, "sha512-bzyZ1e88w9O1iNJbKnOlvYTrWPDl46O1bG0D3XInv+9tkPrxrN8jUUTiFlDkkmKWgn1M6CfIA13SuGqOa9Korw=="],
 
     "sigstore": ["sigstore@4.1.0", "", { "dependencies": { "@sigstore/bundle": "^4.0.0", "@sigstore/core": "^3.1.0", "@sigstore/protobuf-specs": "^0.5.0", "@sigstore/sign": "^4.1.0", "@sigstore/tuf": "^4.0.1", "@sigstore/verify": "^3.1.0" } }, "sha512-/fUgUhYghuLzVT/gaJoeVehLCgZiUxPCPMcyVNY0lIf/cTCz58K/WTI7PefDarXxp9nUKpEwg1yyz3eSBMTtgA=="],
+
+    "simple-xml-to-json": ["simple-xml-to-json@1.2.3", "", {}, "sha512-kWJDCr9EWtZ+/EYYM5MareWj2cRnZGF93YDNpH4jQiHB+hBIZnfPFSQiVMzZOdk+zXWqTZ/9fTeQNu2DqeiudA=="],
 
     "slash": ["slash@3.0.0", "", {}, "sha512-g9Q1haeby36OSStwb4ntCGGGaKsaVSjQ68fBxoQcutl5fS1vuY18H3wSt3jFyFtrkx+Kz0V1G85A4MyAdDMi2Q=="],
 
@@ -820,7 +973,11 @@
 
     "ssri": ["ssri@13.0.1", "", { "dependencies": { "minipass": "^7.0.3" } }, "sha512-QUiRf1+u9wPTL/76GTYlKttDEBWV1ga9ZXW8BG6kfdeyyM8LGPix9gROyg9V2+P0xNyF3X2Go526xKFdMZrHSQ=="],
 
+    "stage-js": ["stage-js@1.0.1", "", {}, "sha512-cz14aPp/wY0s3bkb/B93BPP5ZAEhgBbRmAT3CCDqert8eCAqIpQ0RB2zpK8Ksxf+Pisl5oTzvPHtL4CVzzeHcw=="],
+
     "string-width": ["string-width@4.2.3", "", { "dependencies": { "emoji-regex": "^8.0.0", "is-fullwidth-code-point": "^3.0.0", "strip-ansi": "^6.0.1" } }, "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g=="],
+
+    "string_decoder": ["string_decoder@1.3.0", "", { "dependencies": { "safe-buffer": "~5.2.0" } }, "sha512-hkRX8U1WjJFd8LsDJ2yQ/wWWxaopEsABU1XfkM8A+j0+85JAGppt16cr1Whg6KIbb4okU6Mql6BOj+uup/wKeA=="],
 
     "strip-ansi": ["strip-ansi@6.0.1", "", { "dependencies": { "ansi-regex": "^5.0.1" } }, "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A=="],
 
@@ -830,17 +987,25 @@
 
     "strnum": ["strnum@2.2.0", "", {}, "sha512-Y7Bj8XyJxnPAORMZj/xltsfo55uOiyHcU2tnAVzHUnSJR/KsEX+9RoDeXEnsXtl/CX4fAcrt64gZ13aGaWPeBg=="],
 
+    "strtok3": ["strtok3@6.3.0", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "peek-readable": "^4.1.0" } }, "sha512-fZtbhtvI9I48xDSywd/somNqgUHl2L2cstmXCCif0itOf96jeW18MBSyrLuNicYQVkvpOxkZtkzujiTJ9LW5Jw=="],
+
     "supports-preserve-symlinks-flag": ["supports-preserve-symlinks-flag@1.0.0", "", {}, "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w=="],
 
     "tar": ["tar@7.5.9", "", { "dependencies": { "@isaacs/fs-minipass": "^4.0.0", "chownr": "^3.0.0", "minipass": "^7.1.2", "minizlib": "^3.1.0", "yallist": "^5.0.0" } }, "sha512-BTLcK0xsDh2+PUe9F6c2TlRp4zOOBMTkoQHQIWSIzI0R7KG46uEwq4OPk2W7bZcprBMsuaeFsqwYr7pjh6CuHg=="],
 
     "term-size": ["term-size@2.2.1", "", {}, "sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg=="],
 
+    "three": ["three@0.177.0", "", {}, "sha512-EiXv5/qWAaGI+Vz2A+JfavwYCMdGjxVsrn3oBwllUoqYeaBO75J63ZfyaQKoiLrqNHoTlUc6PFgMXnS0kI45zg=="],
+
+    "tinycolor2": ["tinycolor2@1.6.0", "", {}, "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw=="],
+
     "tinyglobby": ["tinyglobby@0.2.15", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.3" } }, "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ=="],
 
     "tmp": ["tmp@0.2.5", "", {}, "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow=="],
 
     "to-regex-range": ["to-regex-range@5.0.1", "", { "dependencies": { "is-number": "^7.0.0" } }, "sha512-65P7iz6X5yEr1cwcgvQxbbIw7Uk3gOy5dIdtZ4rDveLqhrdJP+Li/Hx6tyK0NEb+2GCyneCMJiGqrADCSNk8sQ=="],
+
+    "token-types": ["token-types@4.2.1", "", { "dependencies": { "@tokenizer/token": "^0.3.0", "ieee754": "^1.2.1" } }, "sha512-6udB24Q737UD/SDsKAHI9FCRP7Bqc9D/MQUV02ORQg5iskjtLJlZJNdN4kKtcdtwCeWIwIHDGaUsTsCCAa8sFQ=="],
 
     "treeverse": ["treeverse@3.0.0", "", {}, "sha512-gcANaAnd2QDZFmHFEOF4k7uc1J/6a6z3DJMd/QwEyxLoKGiptJRwid582r7QIsFlFMIZ3SnxfS52S4hm2DHkuQ=="],
 
@@ -860,6 +1025,8 @@
 
     "upath": ["upath@1.2.0", "", {}, "sha512-aZwGpamFO61g3OlfT7OQCHqhGnW43ieH9WZeP7QxN/G/jS4jfqUkZxoryvJgVPEcrl5NL/ggHsSmLMHuH64Lhg=="],
 
+    "utif2": ["utif2@4.1.0", "", { "dependencies": { "pako": "^1.0.11" } }, "sha512-+oknB9FHrJ7oW7A2WZYajOcv4FcDR4CfoGB0dPNfxbi4GO05RRnFmt5oa23+9w32EanrYcSJWspUiJkLMs+37w=="],
+
     "util-deprecate": ["util-deprecate@1.0.2", "", {}, "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw=="],
 
     "validate-npm-package-license": ["validate-npm-package-license@3.0.4", "", { "dependencies": { "spdx-correct": "^3.0.0", "spdx-expression-parse": "^3.0.0" } }, "sha512-DpKm2Ui/xN7/HQKCtpZxoRWBhZ9Z0kqtygG8XCgNQ8ZlDnxuQmWhj566j8fN4Cu3/JmbhsDo7fcAJq4s9h27Ew=="],
@@ -867,6 +1034,8 @@
     "validate-npm-package-name": ["validate-npm-package-name@7.0.2", "", {}, "sha512-hVDIBwsRruT73PbK7uP5ebUt+ezEtCmzZz3F59BSr2F6OVFnJ/6h8liuvdLrQ88Xmnk6/+xGGuq+pG9WwTuy3A=="],
 
     "walk-up-path": ["walk-up-path@4.0.0", "", {}, "sha512-3hu+tD8YzSLGuFYtPRb48vdhKMi0KQV5sn+uWr8+7dMEq/2G/dtLrdDinkLjqq5TIbIBjYJ4Ax/n3YiaW7QM8A=="],
+
+    "web-tree-sitter": ["web-tree-sitter@0.25.10", "", { "peerDependencies": { "@types/emscripten": "^1.40.0" }, "optionalPeers": ["@types/emscripten"] }, "sha512-Y09sF44/13XvgVKgO2cNDw5rGk6s26MgoZPXLESvMXeefBf7i6/73eFurre0IsTW6E14Y0ArIzhUMmjoc7xyzA=="],
 
     "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
 
@@ -876,6 +1045,12 @@
 
     "write-file-atomic": ["write-file-atomic@7.0.1", "", { "dependencies": { "signal-exit": "^4.0.1" } }, "sha512-OTIk8iR8/aCRWBqvxrzxR0hgxWpnYBblY1S5hDWBQfk/VFmJwzmJgQFN3WsoUKHISv2eAwe+PpbUzyL1CKTLXg=="],
 
+    "xml-parse-from-string": ["xml-parse-from-string@1.0.1", "", {}, "sha512-ErcKwJTF54uRzzNMXq2X5sMIy88zJvfN2DmdoQvy7PAFJ+tPRU6ydWuOKNMyfmOjdyBQTFREi60s0Y0SyI0G0g=="],
+
+    "xml2js": ["xml2js@0.5.0", "", { "dependencies": { "sax": ">=0.6.0", "xmlbuilder": "~11.0.0" } }, "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA=="],
+
+    "xmlbuilder": ["xmlbuilder@11.0.1", "", {}, "sha512-fDlsI/kFEx7gLvbecc0/ohLG50fugQp8ryHzMTuW9vSa1GJ0XYWKnhsUx7oie3G98+r56aTQIUB4kht42R3JvA=="],
+
     "y18n": ["y18n@5.0.8", "", {}, "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA=="],
 
     "yallist": ["yallist@5.0.0", "", {}, "sha512-YgvUTfwqyc7UXVMrB+SImsVYSmTS8X/tSrtdNZMImM+n7+QTriRXyXim0mBrTXNeqzVF0KWGgHPeiyViFFrNDw=="],
@@ -884,6 +1059,10 @@
 
     "yargs-parser": ["yargs-parser@21.1.1", "", {}, "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw=="],
 
+    "yoga-layout": ["yoga-layout@3.2.1", "", {}, "sha512-0LPOt3AxKqMdFBZA3HBAt/t/8vIKq7VaQYbuA8WxCgung+p9TVyKRYdpvCb80HcdTN2NkbIKbhNwKUfm3tQywQ=="],
+
+    "zod": ["zod@3.25.76", "", {}, "sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ=="],
+
     "@aws-crypto/sha1-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@aws-crypto/sha256-browser/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
@@ -891,6 +1070,8 @@
     "@aws-crypto/util/@smithy/util-utf8": ["@smithy/util-utf8@2.3.0", "", { "dependencies": { "@smithy/util-buffer-from": "^2.2.0", "tslib": "^2.6.2" } }, "sha512-R8Rdn8Hy72KKcebgLiv8jQcQkXoLMOGGv5uI1/k0l+snqkOzQ1R0ChUBCxWMlBsFMekWjq0wRudIweFs7sKT5A=="],
 
     "@changesets/parse/js-yaml": ["js-yaml@4.1.1", "", { "dependencies": { "argparse": "^2.0.1" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-qQKT4zQxXl8lLwBtHMWwaTcGfFOZviOJet3Oy/xmGk2gZH677CJM9EvtfdSkgWcATZhj/55JZ0rmy3myCT5lsA=="],
+
+    "@jimp/core/mime": ["mime@3.0.0", "", { "bin": { "mime": "cli.js" } }, "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A=="],
 
     "@manypkg/find-root/@types/node": ["@types/node@12.20.55", "", {}, "sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ=="],
 
@@ -916,6 +1097,8 @@
 
     "execa/signal-exit": ["signal-exit@3.0.7", "", {}, "sha512-wnD2ZE+l+SPC/uoS0vXeE9L1+0wuaMqKlfz9AMUo38JsyLSBWSFcHR1Rri62LZc12vLr1gb3jl7iwQhgwpAbGQ=="],
 
+    "image-q/@types/node": ["@types/node@16.9.1", "", {}, "sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g=="],
+
     "micromatch/picomatch": ["picomatch@2.3.1", "", {}, "sha512-JU3teHTNjmE2VCGFzuY8EXzCDVwEqB2a8fsIvwaStHhAWJEeVd1o1QD80CU6+ZdEXXSLbSsuLwJjkCBWqRQUVA=="],
 
     "minipass-flush/minipass": ["minipass@3.3.6", "", { "dependencies": { "yallist": "^4.0.0" } }, "sha512-DxiNidxSEK+tHG6zOIklvNOwm3hvCrbUrdtzY74U6HKTJxvIDfOUL5W5P2Ghd3DTkhhKPYGqeNUIh5qcM4YBfw=="],
@@ -925,6 +1108,8 @@
     "node-gyp/which": ["which@6.0.1", "", { "dependencies": { "isexe": "^4.0.0" }, "bin": { "node-which": "bin/which.js" } }, "sha512-oGLe46MIrCRqX7ytPUf66EAYvdeMIZYn3WaocqqKZAxrBpkqHfL/qvTyJ/bTk5+AqHCjXmrv3CEWgy368zhRUg=="],
 
     "normalize-package-data/hosted-git-info": ["hosted-git-info@7.0.2", "", { "dependencies": { "lru-cache": "^10.0.1" } }, "sha512-puUZAUKT5m8Zzvs72XWy3HtvVbTWljRE66cP60bxJzAqf2DgICo7lYTY2IHUmLnNpjYvw5bvmoHvPc0QO2a62w=="],
+
+    "pixelmatch/pngjs": ["pngjs@6.0.0", "", {}, "sha512-TRzzuFRRmEoSW/p1KVAmiOgPco2Irlah+bGFCeNfJXxxYGwSw7YwAOAcd7X28K/m5bjBWKsC29KyoMfHbypayg=="],
 
     "promise-retry/retry": ["retry@0.12.0", "", {}, "sha512-9LkiTwjUh6rT555DtE9rTX+BKByPfrMzEAtnlEtdEwr3Nkffwiihqe2bWADg+OQRjt9gl6ICdmB/ZFDCGAtSow=="],
 

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "@aws-sdk/client-sts": "^3.1000.0",
     "@octokit/webhooks": "^13.7.1",
     "@octokit/webhooks-types": "^7.6.1",
+    "@opentui/core": "^0.1.84",
     "@pulumi/aws": "^7.20.0",
     "@pulumi/pulumi": "^3.120.0",
     "commander": "^14.0.3"

--- a/src/app/register-commands.ts
+++ b/src/app/register-commands.ts
@@ -3,6 +3,7 @@ import { registerCloneCommand } from "../command/clone.js";
 import { registerAddCommand } from "../command/a.js";
 import { registerRemoveCommand } from "../command/rm.js";
 import { registerRunCommand } from "../command/run.js";
+import { registerUiCommand } from "../command/ui.js";
 import { registerAwsCommand } from "../command/aws/index.js";
 
 /**
@@ -17,6 +18,7 @@ export function registerCommands(program: Command): void {
   registerAddCommand(program);
   registerRemoveCommand(program);
   registerRunCommand(program);
+  registerUiCommand(program);
   registerAwsCommand(program);
 }
 

--- a/src/command/a.ts
+++ b/src/command/a.ts
@@ -1,16 +1,22 @@
 import type { Command } from "commander";
 import {
   assertNonEmpty,
-  listDirectory,
   selectOrQueryWithFzf,
   selectWithFzf,
 } from "../shared/command/interactive.js";
+import {
+  addOrAttachWorktree,
+  createSkipperPaths,
+  ensureWorktreeDirectory,
+  listRepos,
+  listWorktreesForRepo,
+  resolveWorktreeName,
+  type SkipperPaths,
+} from "../worktree/service.js";
 
 type WorktreeSelection = {
   repo: string;
   worktree: string;
-  targetWorktreePath: string;
-  repoPath: string;
 };
 
 /**
@@ -33,11 +39,9 @@ export function registerAddCommand(program: Command): void {
  * @category Worktree
  */
 async function runAddCommand(): Promise<void> {
-  const githubDir = `${process.env.HOME}/.local/share/github`;
-  const worktreeBaseDir = `${process.env.HOME}/.local/share/skipper/worktree`;
-  const selection = await selectWorktree(githubDir, worktreeBaseDir);
-  await ensureWorktreeExists(selection);
-  await attachOrStartTmux(selection);
+  const paths = createSkipperPaths();
+  const selection = await selectWorktree(paths);
+  await addOrAttachWorktree(paths, selection.repo, selection.worktree);
 }
 
 /**
@@ -47,10 +51,9 @@ async function runAddCommand(): Promise<void> {
  * @category Worktree
  */
 async function selectWorktree(
-  githubDir: string,
-  worktreeBaseDir: string,
+  paths: SkipperPaths,
 ): Promise<WorktreeSelection> {
-  const repoList = await listDirectory(githubDir);
+  const repoList = await listRepos(paths);
   assertNonEmpty(repoList, "No repositories found in ~/.local/share/github");
   const repo = await selectWithFzf(repoList, "Select repository: ");
   if (!repo) {
@@ -58,9 +61,8 @@ async function selectWorktree(
     process.exit(0);
   }
 
-  const worktreeDir = `${worktreeBaseDir}/${repo}`;
-  await Bun.$`mkdir -p ${worktreeDir}`;
-  const existingWorktrees = await listDirectory(worktreeDir);
+  await ensureWorktreeDirectory(paths, repo);
+  const existingWorktrees = await listWorktreesForRepo(paths, repo);
   const input = await selectOrQueryWithFzf(
     existingWorktrees,
     existingWorktrees.length > 0
@@ -76,138 +78,5 @@ async function selectWorktree(
   return {
     repo,
     worktree,
-    targetWorktreePath: `${worktreeDir}/${worktree}`,
-    repoPath: `${githubDir}/${repo}`,
   };
-}
-
-/**
- * Ensure selected worktree exists.
- *
- * @since 1.0.0
- * @category Worktree
- */
-async function ensureWorktreeExists(selection: WorktreeSelection): Promise<void> {
-  const exists = await directoryExists(selection.targetWorktreePath);
-  if (exists) {
-    console.log(`Attaching to existing worktree: ${selection.targetWorktreePath}`);
-    return;
-  }
-
-  console.log(`Creating new worktree: ${selection.worktree}`);
-  const branchExists = await gitBranchExists(selection.repoPath, selection.worktree);
-  if (branchExists) {
-    await Bun.$`git -C ${selection.repoPath} worktree add ${selection.targetWorktreePath} ${selection.worktree}`;
-    return;
-  }
-  await Bun.$`git -C ${selection.repoPath} worktree add ${selection.targetWorktreePath} -b ${selection.worktree}`;
-}
-
-/**
- * Attach to existing tmux session or create one.
- *
- * @since 1.0.0
- * @category Worktree
- */
-async function attachOrStartTmux(selection: WorktreeSelection): Promise<void> {
-  const sessionName = `${selection.repo}-${selection.worktree}`;
-  const running = await tmuxSessionExists(sessionName);
-  const inTmux = process.env.TMUX !== undefined;
-  if (running) {
-    await switchOrAttachSession(sessionName, inTmux);
-    return;
-  }
-  await createTmuxSession(sessionName, selection.targetWorktreePath, inTmux);
-}
-
-/**
- * Resolve typed or selected worktree name.
- *
- * @since 1.0.0
- * @category Worktree
- */
-function resolveWorktreeName(worktreeInput: string | undefined): string | undefined {
-  if (!worktreeInput) return undefined;
-  const lines = worktreeInput.trim().split("\n");
-  const query = lines[0] || "";
-  const selection = lines[1] || "";
-  if (selection && selection !== "[new]") {
-    return selection;
-  }
-  if (query) {
-    return query;
-  }
-  return undefined;
-}
-
-/**
- * Check whether directory exists.
- *
- * @since 1.0.0
- * @category Worktree
- */
-async function directoryExists(path: string): Promise<boolean> {
-  const result = await Bun.$`test -d ${path} && echo "yes" || echo "no"`.text();
-  return result.trim() === "yes";
-}
-
-/**
- * Check whether git branch exists.
- *
- * @since 1.0.0
- * @category Worktree
- */
-async function gitBranchExists(repoPath: string, branch: string): Promise<boolean> {
-  const ref = `refs/heads/${branch}`;
-  const result = await Bun.$`git -C ${repoPath} show-ref --verify --quiet ${ref}`.nothrow();
-  if (result.exitCode === 0) return true;
-  if (result.exitCode === 1) return false;
-  const stderr = result.stderr.toString().trim();
-  throw new Error(stderr || `git show-ref failed with code ${result.exitCode}`);
-}
-
-/**
- * Check whether tmux session exists.
- *
- * @since 1.0.0
- * @category Worktree
- */
-async function tmuxSessionExists(sessionName: string): Promise<boolean> {
-  const output = await Bun.$`tmux has-session -t ${sessionName} 2>/dev/null && echo "yes" || echo "no"`.text();
-  return output.trim() === "yes";
-}
-
-/**
- * Switch or attach to tmux session.
- *
- * @since 1.0.0
- * @category Worktree
- */
-async function switchOrAttachSession(sessionName: string, inTmux: boolean): Promise<void> {
-  if (inTmux) {
-    console.log(`Switching to tmux session: ${sessionName}`);
-    await Bun.$`tmux switch-client -t ${sessionName}`;
-    return;
-  }
-  console.log(`Attaching to existing tmux session: ${sessionName}`);
-  await Bun.$`tmux attach-session -t ${sessionName}`;
-}
-
-/**
- * Create tmux session and attach/switch.
- *
- * @since 1.0.0
- * @category Worktree
- */
-async function createTmuxSession(
-  sessionName: string,
-  worktreePath: string,
-  inTmux: boolean,
-): Promise<void> {
-  console.log(`Starting new tmux session: ${sessionName}`);
-  if (inTmux) {
-    await Bun.$`tmux new-session -s ${sessionName} -c ${worktreePath} -d && tmux switch-client -t ${sessionName}`;
-    return;
-  }
-  await Bun.$`tmux new-session -s ${sessionName} -c ${worktreePath}`;
 }

--- a/src/command/rm.ts
+++ b/src/command/rm.ts
@@ -1,15 +1,14 @@
 import type { Command } from "commander";
 import {
   assertNonEmpty,
-  listDirectory,
   selectWithFzf,
 } from "../shared/command/interactive.js";
-
-type WorktreeRef = {
-  repo: string;
-  worktree: string;
-  path: string;
-};
+import {
+  collectWorktrees,
+  createSkipperPaths,
+  removeWorktree,
+  type WorktreeRef,
+} from "../worktree/service.js";
 
 type RemoveCommandOptions = {
   force?: boolean;
@@ -25,7 +24,10 @@ export function registerRemoveCommand(program: Command): void {
   program
     .command("rm")
     .description("Remove a worktree (repo+worktree)")
-    .option("-f, --force", "Force remove worktree with uncommitted changes")
+    .option(
+      "-f, --force",
+      "Force remove worktree with uncommitted changes (git worktree remove --force)",
+    )
     .action(runRemoveCommand);
 }
 
@@ -37,38 +39,15 @@ export function registerRemoveCommand(program: Command): void {
  */
 async function runRemoveCommand(options: RemoveCommandOptions = {}): Promise<void> {
   const force = options.force ?? true;
-  const worktreeBaseDir = `${process.env.HOME}/.local/share/skipper/worktree`;
-  const allWorktrees = await collectWorktrees(worktreeBaseDir);
+  const paths = createSkipperPaths();
+  const allWorktrees = await collectWorktrees(paths);
   assertNonEmpty(allWorktrees, "No worktrees found");
   const selected = await selectWorktree(allWorktrees);
   if (!selected) {
     console.log("No worktree selected");
     process.exit(0);
   }
-  await removeWorktree(selected, force);
-}
-
-/**
- * Collect all worktrees under base path.
- *
- * @since 1.0.0
- * @category Worktree
- */
-async function collectWorktrees(worktreeBaseDir: string): Promise<WorktreeRef[]> {
-  const repos = await listDirectory(worktreeBaseDir);
-  if (repos.length === 0) {
-    console.error("No worktrees found in ~/.local/share/skipper/worktree");
-    process.exit(1);
-  }
-  const allWorktrees: WorktreeRef[] = [];
-  for (const repo of repos) {
-    const repoDir = `${worktreeBaseDir}/${repo}`;
-    const worktrees = await listDirectory(repoDir);
-    for (const worktree of worktrees) {
-      allWorktrees.push({ repo, worktree, path: `${repoDir}/${worktree}` });
-    }
-  }
-  return allWorktrees;
+  await removeWorktree(paths, selected, force);
 }
 
 /**
@@ -86,48 +65,6 @@ async function selectWorktree(worktrees: WorktreeRef[]): Promise<WorktreeRef | u
 }
 
 /**
- * Remove worktree and tmux session.
- *
- * @since 1.0.0
- * @category Worktree
- */
-async function removeWorktree(target: WorktreeRef, force: boolean): Promise<void> {
-  const githubDir = `${process.env.HOME}/.local/share/github`;
-  const repoPath = `${githubDir}/${target.repo}`;
-  const sessionName = `${target.repo}-${target.worktree}`;
-  const name = `${target.repo}/${target.worktree}`;
-  console.log(`Removing worktree: ${name}`);
-  await removeGitWorktree(repoPath, target.path, force);
-  await Bun.$`rm -rf ${target.path}`;
-  if (await tmuxSessionExists(sessionName)) {
-    await Bun.$`tmux kill-session -t ${sessionName}`;
-    console.log(`Killed tmux session: ${sessionName}`);
-  }
-  console.log(`Removed worktree: ${name}`);
-}
-
-/**
- * Remove git worktree from repository.
- *
- * @since 1.0.0
- * @category Worktree
- */
-async function removeGitWorktree(
-  repoPath: string,
-  worktreePath: string,
-  force: boolean,
-): Promise<void> {
-  const result = force
-    ? await Bun.$`git -C ${repoPath} worktree remove --force ${worktreePath}`.nothrow()
-    : await Bun.$`git -C ${repoPath} worktree remove ${worktreePath}`.nothrow();
-  if (result.exitCode === 0) return;
-  const command = force ? "git worktree remove --force" : "git worktree remove";
-  throw new Error(
-    formatRemoveGitWorktreeError(result.stderr.toString(), result.exitCode, command),
-  );
-}
-
-/**
  * Build remove-git-worktree error message.
  *
  * @since 1.0.1
@@ -141,15 +78,4 @@ export function formatRemoveGitWorktreeError(
   const trimmed = stderr.trim();
   if (trimmed.length > 0) return trimmed;
   return `${command} failed with code ${exitCode}`;
-}
-
-/**
- * Check tmux session existence.
- *
- * @since 1.0.0
- * @category Worktree
- */
-async function tmuxSessionExists(sessionName: string): Promise<boolean> {
-  const output = await Bun.$`tmux has-session -t ${sessionName} 2>/dev/null && echo "yes" || echo "no"`.text();
-  return output.trim() === "yes";
 }

--- a/src/command/run.ts
+++ b/src/command/run.ts
@@ -1,9 +1,9 @@
 import type { Command } from "commander";
 import {
   assertNonEmpty,
-  listDirectory,
   selectWithFzf,
 } from "../shared/command/interactive.js";
+import { createSkipperPaths, listRepos, runPromptInRepo } from "../worktree/service.js";
 
 /**
  * Register run command.
@@ -26,18 +26,14 @@ export function registerRunCommand(program: Command): void {
  * @category Worktree
  */
 async function runCommand(prompt: string): Promise<void> {
-  const baseDir = `${process.env.HOME}/.local/share/github`;
-  const repoList = await listDirectory(baseDir);
+  const paths = createSkipperPaths();
+  const repoList = await listRepos(paths);
   assertNonEmpty(repoList, "No repositories found in ~/.local/share/github");
   const repo = await selectWithFzf(repoList, "Select repository: ");
   if (!repo) {
     console.log("No repository selected");
     process.exit(0);
   }
-  const repoPath = `${baseDir}/${repo}`;
   console.log(`Selected: ${repo}`);
-  console.log("Pulling latest changes...");
-  await Bun.$`git -C ${repoPath} pull`;
-  console.log("Running opencode...");
-  await Bun.$`opencode run ${prompt}`.cwd(repoPath);
+  await runPromptInRepo(paths, repo, prompt);
 }

--- a/src/command/ui.ts
+++ b/src/command/ui.ts
@@ -1,0 +1,36 @@
+import type { Command } from "commander";
+import { printUiFallback } from "./ui/fallback.js";
+
+/**
+ * Register local dashboard UI command.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+export function registerUiCommand(program: Command): void {
+  program
+    .command("ui")
+    .description("Open local worktree dashboard UI")
+    .action(runUiCommand);
+}
+
+/**
+ * Execute OpenTUI dashboard command.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+async function runUiCommand(): Promise<void> {
+  if (!process.stdin.isTTY || !process.stdout.isTTY) {
+    printUiFallback("`skipper ui` needs an interactive terminal");
+    process.exit(1);
+  }
+  try {
+    const { runUiTui } = await import("./ui/tui.js");
+    await runUiTui();
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error);
+    printUiFallback(`UI failed to start: ${message}`);
+    process.exit(1);
+  }
+}

--- a/src/command/ui/actions.test.ts
+++ b/src/command/ui/actions.test.ts
@@ -1,0 +1,18 @@
+import { expect, test } from "bun:test";
+import { isConfirmationAccepted, normalizeRunPrompt } from "./actions.js";
+
+test("normalizeRunPrompt trims and keeps value", () => {
+  expect(normalizeRunPrompt("  fix CI  ")).toBe("fix CI");
+});
+
+test("normalizeRunPrompt returns undefined for empty", () => {
+  expect(normalizeRunPrompt("   ")).toBeUndefined();
+});
+
+test("isConfirmationAccepted checks yes case-insensitively", () => {
+  expect(isConfirmationAccepted("YeS")).toBe(true);
+});
+
+test("isConfirmationAccepted rejects other values", () => {
+  expect(isConfirmationAccepted("no")).toBe(false);
+});

--- a/src/command/ui/actions.ts
+++ b/src/command/ui/actions.ts
@@ -1,0 +1,112 @@
+import {
+  addOrAttachWorktree,
+  removeWorktree,
+  runPromptInRepo,
+  type SkipperPaths,
+} from "../../worktree/service.js";
+import type { UiActionId, UiWorktreeState } from "./model.js";
+
+export type UiActionInput = {
+  actionId: UiActionId;
+  paths: SkipperPaths;
+  selectedWorktree?: UiWorktreeState;
+  promptInput?: string;
+  confirmationInput?: string;
+};
+
+export type UiActionResult = {
+  statusMessage: string;
+  shouldRefresh: boolean;
+  shouldExit: boolean;
+};
+
+/**
+ * Execute one UI action and return status outcome.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+export async function executeUiAction(input: UiActionInput): Promise<UiActionResult> {
+  if (input.actionId === "quit") {
+    return { statusMessage: "Bye", shouldRefresh: false, shouldExit: true };
+  }
+  if (input.actionId === "refresh") {
+    return { statusMessage: "Refreshed", shouldRefresh: true, shouldExit: false };
+  }
+  const selectedWorktree = input.selectedWorktree;
+  if (!selectedWorktree) {
+    return noSelectionResult("Select a worktree first");
+  }
+  if (input.actionId === "checkout") {
+    await addOrAttachWorktree(
+      input.paths,
+      selectedWorktree.repo,
+      selectedWorktree.worktree,
+    );
+    return {
+      statusMessage: `Attached ${selectedWorktree.repo}/${selectedWorktree.worktree}`,
+      shouldRefresh: false,
+      shouldExit: false,
+    };
+  }
+  if (input.actionId === "remove") {
+    if (!isConfirmationAccepted(input.confirmationInput)) {
+      return noSelectionResult("Removal cancelled");
+    }
+    await removeWorktree(input.paths, selectedWorktree);
+    return {
+      statusMessage: `Removed ${selectedWorktree.repo}/${selectedWorktree.worktree}`,
+      shouldRefresh: true,
+      shouldExit: false,
+    };
+  }
+  if (input.actionId === "run") {
+    const prompt = normalizeRunPrompt(input.promptInput);
+    if (!prompt) {
+      return noSelectionResult("Enter prompt first");
+    }
+    await runPromptInRepo(input.paths, selectedWorktree.repo, prompt);
+    return {
+      statusMessage: `Run complete for ${selectedWorktree.repo}`,
+      shouldRefresh: false,
+      shouldExit: false,
+    };
+  }
+  return noSelectionResult("Unsupported action");
+}
+
+/**
+ * Normalize run prompt input.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+export function normalizeRunPrompt(value: string | undefined): string | undefined {
+  const trimmed = value?.trim();
+  if (!trimmed) return undefined;
+  return trimmed;
+}
+
+/**
+ * Validate remove confirmation input.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+export function isConfirmationAccepted(value: string | undefined): boolean {
+  return value?.trim().toLowerCase() === "yes";
+}
+
+/**
+ * Build standard selection-missing action result.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+function noSelectionResult(statusMessage: string): UiActionResult {
+  return {
+    statusMessage,
+    shouldRefresh: false,
+    shouldExit: false,
+  };
+}

--- a/src/command/ui/fallback.ts
+++ b/src/command/ui/fallback.ts
@@ -1,0 +1,13 @@
+/**
+ * Print fallback message when UI cannot start.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+export function printUiFallback(reason: string): void {
+  console.error(reason);
+  console.error("Use non-UI commands instead:");
+  console.error("- skipper a");
+  console.error("- skipper rm");
+  console.error('- skipper run "<prompt>"');
+}

--- a/src/command/ui/model.test.ts
+++ b/src/command/ui/model.test.ts
@@ -1,0 +1,40 @@
+import { expect, test } from "bun:test";
+import { resolveSelectedWorktreeKey, type UiWorktreeState } from "./model.js";
+
+test("resolveSelectedWorktreeKey keeps valid selected key", () => {
+  const worktrees: UiWorktreeState[] = [
+    {
+      key: "repo/feature",
+      repo: "repo",
+      worktree: "feature",
+      path: "/tmp/repo/feature",
+      sessionName: "repo-feature",
+      sessionRunning: false,
+    },
+    {
+      key: "repo/fix",
+      repo: "repo",
+      worktree: "fix",
+      path: "/tmp/repo/fix",
+      sessionName: "repo-fix",
+      sessionRunning: true,
+    },
+  ];
+  const selected = resolveSelectedWorktreeKey(worktrees, "repo/fix");
+  expect(selected).toBe("repo/fix");
+});
+
+test("resolveSelectedWorktreeKey falls back to first entry", () => {
+  const worktrees: UiWorktreeState[] = [
+    {
+      key: "repo/feature",
+      repo: "repo",
+      worktree: "feature",
+      path: "/tmp/repo/feature",
+      sessionName: "repo-feature",
+      sessionRunning: false,
+    },
+  ];
+  const selected = resolveSelectedWorktreeKey(worktrees, "repo/missing");
+  expect(selected).toBe("repo/feature");
+});

--- a/src/command/ui/model.ts
+++ b/src/command/ui/model.ts
@@ -1,0 +1,103 @@
+import {
+  collectWorktrees,
+  buildSessionName,
+  tmuxSessionExists,
+  type SkipperPaths,
+} from "../../worktree/service.js";
+
+export type UiActionId = "checkout" | "remove" | "run" | "refresh" | "quit";
+
+export type UiWorktreeState = {
+  key: string;
+  repo: string;
+  worktree: string;
+  path: string;
+  sessionName: string;
+  sessionRunning: boolean;
+};
+
+export type UiState = {
+  worktrees: UiWorktreeState[];
+  selectedWorktreeKey: string | undefined;
+  statusMessage: string;
+};
+
+export type BuildUiStateInput = {
+  paths: SkipperPaths;
+  selectedWorktreeKey?: string;
+  statusMessage?: string;
+};
+
+/**
+ * Build refreshed UI state from filesystem and tmux.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+export async function buildUiState(input: BuildUiStateInput): Promise<UiState> {
+  const worktrees = await buildWorktreeStates(input.paths);
+  const selectedWorktreeKey = resolveSelectedWorktreeKey(
+    worktrees,
+    input.selectedWorktreeKey,
+  );
+  return {
+    worktrees,
+    selectedWorktreeKey,
+    statusMessage: input.statusMessage ?? "Ready",
+  };
+}
+
+/**
+ * Find currently selected worktree item in UI state.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+export function findSelectedWorktree(state: UiState): UiWorktreeState | undefined {
+  const key = state.selectedWorktreeKey;
+  if (!key) return undefined;
+  return state.worktrees.find((worktree) => worktree.key === key);
+}
+
+/**
+ * Resolve selected worktree key with fallback to first value.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+export function resolveSelectedWorktreeKey(
+  worktrees: UiWorktreeState[],
+  selectedWorktreeKey?: string,
+): string | undefined {
+  if (selectedWorktreeKey && worktrees.some((worktree) => worktree.key === selectedWorktreeKey)) {
+    return selectedWorktreeKey;
+  }
+  return worktrees[0]?.key;
+}
+
+/**
+ * Build worktree state list from all local repositories.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+async function buildWorktreeStates(
+  paths: SkipperPaths,
+): Promise<UiWorktreeState[]> {
+  const worktrees = await collectWorktrees(paths);
+  const states: UiWorktreeState[] = [];
+  for (const worktreeRef of worktrees) {
+    const sessionName = buildSessionName(worktreeRef.repo, worktreeRef.worktree);
+    const sessionRunning = await tmuxSessionExists(sessionName);
+    states.push({
+      key: `${worktreeRef.repo}/${worktreeRef.worktree}`,
+      repo: worktreeRef.repo,
+      worktree: worktreeRef.worktree,
+      path: worktreeRef.path,
+      sessionName,
+      sessionRunning,
+    });
+  }
+  states.sort((a, b) => a.key.localeCompare(b.key));
+  return states;
+}

--- a/src/command/ui/tui.ts
+++ b/src/command/ui/tui.ts
@@ -1,0 +1,305 @@
+import {
+  BoxRenderable,
+  InputRenderable,
+  InputRenderableEvents,
+  SelectRenderable,
+  SelectRenderableEvents,
+  TextRenderable,
+  createCliRenderer,
+  type KeyEvent,
+  type SelectOption,
+} from "@opentui/core";
+import { executeUiAction } from "./actions.js";
+import {
+  buildUiState,
+  findSelectedWorktree,
+  type UiActionId,
+  type UiState,
+} from "./model.js";
+import { createSkipperPaths } from "../../worktree/service.js";
+
+type PromptMode = "none" | "runPrompt" | "removeConfirm";
+
+/**
+ * Run local worktree dashboard TUI.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+export async function runUiTui(): Promise<void> {
+  const paths = createSkipperPaths();
+  const renderer = await createCliRenderer({ exitOnCtrlC: true });
+  let state = await buildUiState({ paths, statusMessage: "Ready" });
+  let promptMode: PromptMode = "none";
+  let shuttingDown = false;
+
+  const rootLayout = new BoxRenderable(renderer, {
+    id: "ui-root",
+    width: "100%",
+    height: "100%",
+    flexDirection: "column",
+    gap: 1,
+    padding: 1,
+    backgroundColor: "#11141a",
+  });
+  const headerText = new TextRenderable(renderer, {
+    id: "ui-header",
+    content: "Skipper UI - worktree list",
+    fg: "#d9e4f2",
+  });
+  const worktreeBox = new BoxRenderable(renderer, {
+    id: "worktree-box",
+    width: "100%",
+    height: "100%",
+    borderStyle: "rounded",
+    borderColor: "#2a3548",
+    title: "Worktrees",
+    padding: 1,
+    gap: 1,
+  });
+  const worktreeSelect = new SelectRenderable(renderer, {
+    id: "worktree-select",
+    width: "100%",
+    height: 16,
+    options: [],
+    showDescription: true,
+  });
+  const selectedDetail = new TextRenderable(renderer, {
+    id: "selected-detail",
+    content: "No worktree selected",
+    fg: "#b0bccd",
+  });
+  const inputBox = new BoxRenderable(renderer, {
+    id: "input-box",
+    width: "100%",
+    borderStyle: "rounded",
+    borderColor: "#30466a",
+    title: "Input",
+    padding: 1,
+    gap: 1,
+  });
+  const inputHint = new TextRenderable(renderer, {
+    id: "input-hint",
+    content: "",
+    fg: "#d9e4f2",
+  });
+  const inputField = new InputRenderable(renderer, {
+    id: "input-field",
+    width: "100%",
+    placeholder: "",
+    value: "",
+    textColor: "#d9e4f2",
+    focusedBackgroundColor: "#1f2b3d",
+  });
+  const statusLine = new TextRenderable(renderer, {
+    id: "status-line",
+    content: "Ready",
+    fg: "#9fb3c8",
+  });
+  const helpLine = new TextRenderable(renderer, {
+    id: "help-line",
+    content: "Enter checkout | p run prompt | d remove | r refresh | q quit | Esc cancel",
+    fg: "#6f8196",
+  });
+
+  worktreeBox.add(worktreeSelect);
+  worktreeBox.add(selectedDetail);
+  inputBox.add(inputHint);
+  inputBox.add(inputField);
+  rootLayout.add(headerText);
+  rootLayout.add(worktreeBox);
+  rootLayout.add(inputBox);
+  rootLayout.add(statusLine);
+  rootLayout.add(helpLine);
+  renderer.root.add(rootLayout);
+
+  const refreshState = async (statusMessage: string): Promise<void> => {
+    state = await buildUiState({
+      paths,
+      selectedWorktreeKey: state.selectedWorktreeKey,
+      statusMessage,
+    });
+    worktreeSelect.options = toWorktreeOptions(state);
+    statusLine.content = state.statusMessage;
+    updateSelectedDetail();
+  };
+
+  const updateSelectedDetail = (): void => {
+    const selected = findSelectedWorktree(state);
+    if (!selected) {
+      selectedDetail.content = "No worktree selected";
+      return;
+    }
+    const tmuxState = selected.sessionRunning ? "running" : "stopped";
+    selectedDetail.content = `${selected.repo}/${selected.worktree} | tmux ${tmuxState}`;
+  };
+
+  const clearPromptMode = (statusMessage: string): void => {
+    promptMode = "none";
+    inputHint.content = "";
+    inputField.placeholder = "";
+    inputField.value = "";
+    statusLine.content = statusMessage;
+    worktreeSelect.focus();
+  };
+
+  const applyActionResult = async (
+    statusMessage: string,
+    shouldRefresh: boolean,
+    shouldExit: boolean,
+  ): Promise<void> => {
+    if (shouldExit) {
+      shuttingDown = true;
+      renderer.destroy();
+      return;
+    }
+    if (shouldRefresh) {
+      await refreshState(statusMessage);
+      worktreeSelect.focus();
+      return;
+    }
+    statusLine.content = statusMessage;
+    worktreeSelect.focus();
+  };
+
+  const runAction = async (
+    actionId: UiActionId,
+    extras: {
+      promptInput?: string;
+      confirmationInput?: string;
+    } = {},
+  ): Promise<void> => {
+    const result = await executeUiAction({
+      actionId,
+      paths,
+      selectedWorktree: findSelectedWorktree(state),
+      ...extras,
+    });
+    await applyActionResult(result.statusMessage, result.shouldRefresh, result.shouldExit);
+  };
+
+  const startRunPrompt = (): void => {
+    const selected = findSelectedWorktree(state);
+    if (!selected) {
+      statusLine.content = "Select a worktree first";
+      return;
+    }
+    promptMode = "runPrompt";
+    inputHint.content = `Run prompt in ${selected.repo}`;
+    inputField.placeholder = "prompt";
+    inputField.value = "";
+    inputField.focus();
+  };
+
+  const startRemoveConfirm = (): void => {
+    const selected = findSelectedWorktree(state);
+    if (!selected) {
+      statusLine.content = "Select a worktree first";
+      return;
+    }
+    promptMode = "removeConfirm";
+    inputHint.content = `Type yes to remove ${selected.repo}/${selected.worktree}`;
+    inputField.placeholder = "yes";
+    inputField.value = "";
+    inputField.focus();
+  };
+
+  const handlePromptSubmit = async (value: string): Promise<void> => {
+    if (promptMode === "runPrompt") {
+      promptMode = "none";
+      inputHint.content = "";
+      inputField.placeholder = "";
+      inputField.value = "";
+      await runAction("run", { promptInput: value });
+      return;
+    }
+    if (promptMode === "removeConfirm") {
+      promptMode = "none";
+      inputHint.content = "";
+      inputField.placeholder = "";
+      inputField.value = "";
+      await runAction("remove", { confirmationInput: value });
+    }
+  };
+
+  const handleKeypress = async (key: KeyEvent): Promise<void> => {
+    if (key.name === "escape") {
+      if (promptMode !== "none") {
+        clearPromptMode("Input cancelled");
+      } else {
+        shuttingDown = true;
+        renderer.destroy();
+      }
+      return;
+    }
+    if (promptMode !== "none") {
+      return;
+    }
+    if (key.name === "q") {
+      await runAction("quit");
+      return;
+    }
+    if (key.name === "r") {
+      await runAction("refresh");
+      return;
+    }
+    if (key.name === "p") {
+      startRunPrompt();
+      return;
+    }
+    if (key.name === "d") {
+      startRemoveConfirm();
+    }
+  };
+
+  worktreeSelect.on(SelectRenderableEvents.SELECTION_CHANGED, (index: number) => {
+    const selected = state.worktrees[index];
+    state = {
+      ...state,
+      selectedWorktreeKey: selected?.key,
+    };
+    updateSelectedDetail();
+  });
+
+  worktreeSelect.on(SelectRenderableEvents.ITEM_SELECTED, () => {
+    void runAction("checkout");
+  });
+
+  inputField.on(InputRenderableEvents.ENTER, (value: string) => {
+    void handlePromptSubmit(value);
+  });
+
+  renderer.keyInput.on("keypress", (key: KeyEvent) => {
+    void handleKeypress(key);
+  });
+
+  await refreshState(state.statusMessage);
+  worktreeSelect.focus();
+
+  try {
+    while (!renderer.isDestroyed && !shuttingDown) {
+      await Bun.sleep(80);
+    }
+  } finally {
+    if (!renderer.isDestroyed) {
+      renderer.destroy();
+    }
+  }
+}
+
+/**
+ * Build select options for worktree list.
+ *
+ * @since 1.0.2
+ * @category CLI
+ */
+function toWorktreeOptions(state: UiState): SelectOption[] {
+  if (state.worktrees.length === 0) {
+    return [{ name: "No worktrees found", description: "Create one with skipper a" }];
+  }
+  return state.worktrees.map((worktree) => ({
+    name: `${worktree.repo}/${worktree.worktree}`,
+    description: worktree.sessionRunning ? "tmux running" : "tmux stopped",
+    value: worktree.key,
+  }));
+}

--- a/src/worktree/service.test.ts
+++ b/src/worktree/service.test.ts
@@ -1,0 +1,27 @@
+import { expect, test } from "bun:test";
+import {
+  buildSessionName,
+  buildWorktreePath,
+  createSkipperPaths,
+  resolveWorktreeName,
+} from "./service.js";
+
+test("resolveWorktreeName prefers selected row", () => {
+  const value = resolveWorktreeName("feature\nrelease");
+  expect(value).toBe("release");
+});
+
+test("resolveWorktreeName falls back to query", () => {
+  const value = resolveWorktreeName("feature\n[new]");
+  expect(value).toBe("feature");
+});
+
+test("buildSessionName formats repo and worktree", () => {
+  expect(buildSessionName("repo", "feature")).toBe("repo-feature");
+});
+
+test("buildWorktreePath uses configured base path", () => {
+  const paths = createSkipperPaths();
+  const value = buildWorktreePath(paths, "repo", "feature");
+  expect(value.endsWith("/.local/share/skipper/worktree/repo/feature")).toBe(true);
+});

--- a/src/worktree/service.ts
+++ b/src/worktree/service.ts
@@ -1,0 +1,365 @@
+import { listDirectory } from "../shared/command/interactive.js";
+
+export type SkipperPaths = {
+  githubDir: string;
+  worktreeBaseDir: string;
+};
+
+export type WorktreeRef = {
+  repo: string;
+  worktree: string;
+  path: string;
+};
+
+export type AddOrAttachOutcome = {
+  createdWorktree: boolean;
+  sessionName: string;
+};
+
+/**
+ * Build default local paths used by skipper worktree commands.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export function createSkipperPaths(): SkipperPaths {
+  const homeDir = process.env.HOME ?? "";
+  return {
+    githubDir: `${homeDir}/.local/share/github`,
+    worktreeBaseDir: `${homeDir}/.local/share/skipper/worktree`,
+  };
+}
+
+/**
+ * Build canonical tmux session name for one worktree.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export function buildSessionName(repo: string, worktree: string): string {
+  return `${repo}-${worktree}`;
+}
+
+/**
+ * Build absolute repository path for one repo name.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export function buildRepoPath(paths: SkipperPaths, repo: string): string {
+  return `${paths.githubDir}/${repo}`;
+}
+
+/**
+ * Build absolute worktree directory path for one repo.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export function buildWorktreeDir(paths: SkipperPaths, repo: string): string {
+  return `${paths.worktreeBaseDir}/${repo}`;
+}
+
+/**
+ * Build absolute worktree path from repo and worktree names.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export function buildWorktreePath(
+  paths: SkipperPaths,
+  repo: string,
+  worktree: string,
+): string {
+  return `${buildWorktreeDir(paths, repo)}/${worktree}`;
+}
+
+/**
+ * List local repositories from configured github directory.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export async function listRepos(paths: SkipperPaths): Promise<string[]> {
+  return listDirectory(paths.githubDir);
+}
+
+/**
+ * Ensure worktree directory exists for a repository.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export async function ensureWorktreeDirectory(
+  paths: SkipperPaths,
+  repo: string,
+): Promise<string> {
+  const dir = buildWorktreeDir(paths, repo);
+  await Bun.$`mkdir -p ${dir}`;
+  return dir;
+}
+
+/**
+ * List worktrees for one repository.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export async function listWorktreesForRepo(
+  paths: SkipperPaths,
+  repo: string,
+): Promise<string[]> {
+  const worktreeDir = buildWorktreeDir(paths, repo);
+  return listDirectory(worktreeDir);
+}
+
+/**
+ * Collect all local worktrees across all repositories.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export async function collectWorktrees(paths: SkipperPaths): Promise<WorktreeRef[]> {
+  const repos = await listDirectory(paths.worktreeBaseDir);
+  const allWorktrees: WorktreeRef[] = [];
+  for (const repo of repos) {
+    const repoDir = `${paths.worktreeBaseDir}/${repo}`;
+    const worktrees = await listDirectory(repoDir);
+    for (const worktree of worktrees) {
+      allWorktrees.push({ repo, worktree, path: `${repoDir}/${worktree}` });
+    }
+  }
+  return allWorktrees;
+}
+
+/**
+ * Resolve typed or selected worktree value from fzf --print-query output.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export function resolveWorktreeName(worktreeInput: string | undefined): string | undefined {
+  if (!worktreeInput) return undefined;
+  const lines = worktreeInput.trim().split("\n");
+  const query = lines[0] || "";
+  const selection = lines[1] || "";
+  if (selection && selection !== "[new]") {
+    return selection;
+  }
+  if (query) {
+    return query;
+  }
+  return undefined;
+}
+
+/**
+ * Ensure one worktree exists and attach/switch tmux session.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export async function addOrAttachWorktree(
+  paths: SkipperPaths,
+  repo: string,
+  worktree: string,
+): Promise<AddOrAttachOutcome> {
+  const repoPath = buildRepoPath(paths, repo);
+  const targetWorktreePath = buildWorktreePath(paths, repo, worktree);
+  const createdWorktree = await ensureWorktreeExists(repoPath, worktree, targetWorktreePath);
+  const sessionName = buildSessionName(repo, worktree);
+  await attachOrStartTmux(sessionName, targetWorktreePath);
+  return { createdWorktree, sessionName };
+}
+
+/**
+ * Remove one worktree and kill matching tmux session.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export async function removeWorktree(
+  paths: SkipperPaths,
+  target: WorktreeRef,
+  force = true,
+): Promise<void> {
+  const repoPath = buildRepoPath(paths, target.repo);
+  const sessionName = buildSessionName(target.repo, target.worktree);
+  const name = `${target.repo}/${target.worktree}`;
+  console.log(`Removing worktree: ${name}`);
+  await removeGitWorktree(repoPath, target.path, force);
+  await Bun.$`rm -rf ${target.path}`;
+  if (await tmuxSessionExists(sessionName)) {
+    await Bun.$`tmux kill-session -t ${sessionName}`;
+    console.log(`Killed tmux session: ${sessionName}`);
+  }
+  console.log(`Removed worktree: ${name}`);
+}
+
+/**
+ * Pull latest repository changes and run opencode prompt.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export async function runPromptInRepo(
+  paths: SkipperPaths,
+  repo: string,
+  prompt: string,
+): Promise<void> {
+  const repoPath = buildRepoPath(paths, repo);
+  console.log("Pulling latest changes...");
+  await Bun.$`git -C ${repoPath} pull`;
+  console.log("Running opencode...");
+  await Bun.$`opencode run ${prompt}`.cwd(repoPath);
+}
+
+/**
+ * Check whether tmux session exists.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+export async function tmuxSessionExists(sessionName: string): Promise<boolean> {
+  const output = await Bun.$`tmux has-session -t ${sessionName} 2>/dev/null && echo "yes" || echo "no"`.text();
+  return output.trim() === "yes";
+}
+
+/**
+ * Ensure worktree directory exists with branch handling.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+async function ensureWorktreeExists(
+  repoPath: string,
+  worktree: string,
+  targetWorktreePath: string,
+): Promise<boolean> {
+  const exists = await directoryExists(targetWorktreePath);
+  if (exists) {
+    console.log(`Attaching to existing worktree: ${targetWorktreePath}`);
+    return false;
+  }
+  console.log(`Creating new worktree: ${worktree}`);
+  const branchExists = await gitBranchExists(repoPath, worktree);
+  if (branchExists) {
+    await Bun.$`git -C ${repoPath} worktree add ${targetWorktreePath} ${worktree}`;
+    return true;
+  }
+  await Bun.$`git -C ${repoPath} worktree add ${targetWorktreePath} -b ${worktree}`;
+  return true;
+}
+
+/**
+ * Attach to an existing tmux session or create one.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+async function attachOrStartTmux(sessionName: string, worktreePath: string): Promise<void> {
+  const running = await tmuxSessionExists(sessionName);
+  const inTmux = process.env.TMUX !== undefined;
+  if (running) {
+    await switchOrAttachSession(sessionName, inTmux);
+    return;
+  }
+  await createTmuxSession(sessionName, worktreePath, inTmux);
+}
+
+/**
+ * Check whether directory exists.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+async function directoryExists(path: string): Promise<boolean> {
+  const result = await Bun.$`test -d ${path} && echo "yes" || echo "no"`.text();
+  return result.trim() === "yes";
+}
+
+/**
+ * Check whether git branch exists.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+async function gitBranchExists(repoPath: string, branch: string): Promise<boolean> {
+  const ref = `refs/heads/${branch}`;
+  const result = await Bun.$`git -C ${repoPath} show-ref --verify --quiet ${ref}`.nothrow();
+  if (result.exitCode === 0) return true;
+  if (result.exitCode === 1) return false;
+  const stderr = result.stderr.toString().trim();
+  throw new Error(stderr || `git show-ref failed with code ${result.exitCode}`);
+}
+
+/**
+ * Switch or attach to tmux session.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+async function switchOrAttachSession(sessionName: string, inTmux: boolean): Promise<void> {
+  if (inTmux) {
+    console.log(`Switching to tmux session: ${sessionName}`);
+    await Bun.$`tmux switch-client -t ${sessionName}`;
+    return;
+  }
+  console.log(`Attaching to existing tmux session: ${sessionName}`);
+  await Bun.$`tmux attach-session -t ${sessionName}`;
+}
+
+/**
+ * Create tmux session and attach/switch.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+async function createTmuxSession(
+  sessionName: string,
+  worktreePath: string,
+  inTmux: boolean,
+): Promise<void> {
+  console.log(`Starting new tmux session: ${sessionName}`);
+  if (inTmux) {
+    await Bun.$`tmux new-session -s ${sessionName} -c ${worktreePath} -d && tmux switch-client -t ${sessionName}`;
+    return;
+  }
+  await Bun.$`tmux new-session -s ${sessionName} -c ${worktreePath}`;
+}
+
+/**
+ * Remove git worktree from repository.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+async function removeGitWorktree(
+  repoPath: string,
+  worktreePath: string,
+  force: boolean,
+): Promise<void> {
+  const result = force
+    ? await Bun.$`git -C ${repoPath} worktree remove --force ${worktreePath}`.nothrow()
+    : await Bun.$`git -C ${repoPath} worktree remove ${worktreePath}`.nothrow();
+  if (result.exitCode === 0) return;
+  const command = force ? "git worktree remove --force" : "git worktree remove";
+  throw new Error(
+    formatRemoveGitWorktreeError(result.stderr.toString(), result.exitCode, command),
+  );
+}
+
+/**
+ * Build remove-git-worktree error message.
+ *
+ * @since 1.0.2
+ * @category Worktree
+ */
+function formatRemoveGitWorktreeError(
+  stderr: string,
+  exitCode: number,
+  command = "git worktree remove",
+): string {
+  const trimmed = stderr.trim();
+  if (trimmed.length > 0) return trimmed;
+  return `${command} failed with code ${exitCode}`;
+}


### PR DESCRIPTION
## Summary
- add `skipper ui` TUI command for worktree list + keyboard actions (checkout, run prompt, remove, refresh, quit)
- extract shared worktree lifecycle/service helpers and reuse from `a`, `rm`, and `run`
- document UI usage in README, add a minor changeset, and include `@opentui/core`

## Testing
- bun test