### PR TITLE
fix: pass repository string to RepositoryPath.make instead of object

### DIFF
--- a/src/Agent/Service.ts
+++ b/src/Agent/Service.ts
@@ -111,10 +111,7 @@ export const AgentServiceImpl = ServiceMap.make(AgentService, {
         }
 
         const repository = yield* resolveRepositoryName(input.repository);
-        const repositoryPath = RepositoryPath.make({
-          repository,
-          branch: "main",
-        });
+        const repositoryPath = RepositoryPath.make(repository);
         const repositoryExists = yield* fs.exists(repositoryPath);
 
         if (!repositoryExists) {


### PR DESCRIPTION
## Summary

Fixes #54 — `sk run "prompt"` throws:
```
TypeError: The "paths[1]" property must be of type string, got object
    at join (unknown)
```

## Root Cause

`RepositoryPath.make` signature (`src/domain/RepositoryPath.ts:14`) accepts a single `string` argument — the repository name — and passes it directly to `path.join()`.

The call site in `src/Agent/Service.ts:114-117` was incorrectly passing `{ repository, branch: "main" }` (a plain object) instead of the resolved `repository` string. At runtime, `path.join()` received an object as `paths[1]`, causing the TypeError.

## Fix

Single-line change in `src/Agent/Service.ts`:

```diff
- const repositoryPath = RepositoryPath.make({
-   repository,
-   branch: "main",
- });
+ const repositoryPath = RepositoryPath.make(repository);
```

## Scope

- **1 file changed**: `src/Agent/Service.ts`
- **+1 / -4 lines** (5 non-lockfile lines total — well within the 200-line limit)
- No behavior change beyond fixing the crash; `branch: "main"` was never used by `RepositoryPath.make`