### PR TITLE
fix: handle missing worktree directory for newly cloned repos (#53)

### DIFF
--- a/src/internal/FuzzyFindService.ts
+++ b/src/internal/FuzzyFindService.ts
@@ -14,13 +14,27 @@ const resolveSelectionOrQuery = (output: string): string => {
   return selection || query;
 };
 
+const scanDirectory = async (directory: string): Promise<string[]> => {
+  try {
+    return await Array.fromAsync(
+      DIRECTORY_GLOB.scan({ cwd: directory, onlyFiles: false })
+    );
+  } catch {
+    return [];
+  }
+};
+
+/**
+ * Run fzf against the merged list of directory entries and additional options.
+ *
+ * @since 1.2.4
+ * @category Shared
+ */
 const searchWithFzf = async (
   directory: string,
   additionalOptions: readonly string[] = []
 ): Promise<string> => {
-  const entries = await Array.fromAsync(
-    DIRECTORY_GLOB.scan({ cwd: directory, onlyFiles: false })
-  );
+  const entries = await scanDirectory(directory);
   const allOptions = [...additionalOptions, ...entries]
     .filter((entry) => entry.trim().length > 0)
     .sort((a, b) => a.localeCompare(b));


### PR DESCRIPTION
## Summary

Fixes #53 — *Newly cloned repos fails with not existing worktree path*

### Root cause

When a repo is freshly cloned (`skipper clone owner/repo`) and no worktrees have been created yet, the worktree repository directory `~/.local/share/skipper/worktree/<repo>` does not exist.

In `src/internal/FuzzyFindService.ts`, `Bun.Glob.scan({ cwd: directory })` **throws** if `cwd` does not exist. The exception was caught by the outer `Effect.catch` and collapsed to an empty string `""`. Because `additionalOptions` (e.g. `["main"]`) are built inside `searchWithFzf` *after* the scan, they were also discarded, so the fzf picker received no input and returned `""` as the branch.

`TmuxWorkTreeService.create` then received `branch = ""`, which is not `"main"`, and attempted to create a git worktree at `~/.local/share/skipper/worktree/<repo>/` (empty branch segment) — causing the error reported in the issue.

### Fix

Extract a `scanDirectory` helper that wraps `Bun.Glob.scan` in a `try/catch` and returns `[]` when the directory is absent. `searchWithFzf` uses this helper so that `additionalOptions` (including `"main"`) are always surfaced to the fzf picker, even for a freshly cloned repository with no existing worktrees.

### Scope

Single file changed: `src/internal/FuzzyFindService.ts`

| | lines |
|---|---|
| Added | 17 |
| Deleted | 3 |
| **Total non-lockfile** | **20** |

No lockfile changes.