### PR TITLE
fix: prevent start when selection is empty (issue #57)

### DIFF
--- a/src/internal/FuzzyFindService.ts
+++ b/src/internal/FuzzyFindService.ts
@@ -28,11 +28,14 @@ const searchWithFzf = async (
 
   const result = await Bun.$`echo ${input} | fzf --print-query`.nothrow();
 
-  if (result.exitCode === 0 || result.exitCode === FZF_NO_MATCH_EXIT_CODE) {
+  if (result.exitCode === 0) {
     return resolveSelectionOrQuery(result.stdout.toString());
   }
 
-  if (result.exitCode === FZF_CANCELLED_EXIT_CODE) {
+  if (
+    result.exitCode === FZF_NO_MATCH_EXIT_CODE ||
+    result.exitCode === FZF_CANCELLED_EXIT_CODE
+  ) {
     return "";
   }
 


### PR DESCRIPTION
## Summary

Fixes #57: When selecting empty (with create and remove) it starts — it should prevent it.

## Root Cause

In `src/internal/FuzzyFindService.ts`, when `fzf` is run against an empty list (or a list where all items have been removed), it exits with code `1` (`FZF_NO_MATCH_EXIT_CODE`). The previous code handled exit code `0` (match found) and `1` (no match) identically — both called `resolveSelectionOrQuery`, which returns the typed query string as a fallback when there is no selection.

This non-empty string bypassed the `throwOnNotFound` guard downstream, so `create`/`remove` would proceed with the user's typed-but-unmatched query instead of being prevented.

## Fix

Treat `FZF_NO_MATCH_EXIT_CODE` (exit code `1`) the same as `FZF_CANCELLED_EXIT_CODE` (exit code `130`) by returning `""`. This makes the `throwOnNotFound` guard fire correctly, preventing the operation from starting when there are no valid selections.

```diff
- if (result.exitCode === 0 || result.exitCode === FZF_NO_MATCH_EXIT_CODE) {
-   return resolveSelectionOrQuery(result.stdout.toString());
- }
-
- if (result.exitCode === FZF_CANCELLED_EXIT_CODE) {
-   return "";
- }
+ if (result.exitCode === 0) {
+   return resolveSelectionOrQuery(result.stdout.toString());
+ }
+
+ if (
+   result.exitCode === FZF_NO_MATCH_EXIT_CODE ||
+   result.exitCode === FZF_CANCELLED_EXIT_CODE
+ ) {
+   return "";
+ }
```

## Scope

- **Single file changed**: `src/internal/FuzzyFindService.ts`
- **7 non-lockfile lines changed** (5 added, 2 deleted) — well within the 200-line limit
- No behavior change for the happy path (exit code `0` still resolves selection as before)
- No behavior change for cancellation (exit code `130` still returns `""`)
- Empty/no-match case (exit code `1`) now correctly returns `""` → `throwOnNotFound` guard fires → operation is prevented