### PR TITLE
add switch command

### DIFF
--- a/.changeset/smart-bikes-stay.md
+++ b/.changeset/smart-bikes-stay.md
@@ -1,0 +1,5 @@
+---
+"@skippercorp/skipper": patch
+---
+
+Add a top-level `switch` command for filterable repo and branch selection so tmux session switching is quicker without going through the sandbox picker.

--- a/src/Cli.ts
+++ b/src/Cli.ts
@@ -2,13 +2,14 @@ import { Effect, Logger } from "effect";
 import { BunRuntime, BunServices } from "@effect/platform-bun";
 import { CliError, Command } from "effect/unstable/cli";
 import packageJson from "../package.json";
-import { cloneCommand, pickerCommand, sandboxCommand } from "./Sandbox/Cli";
+import { cloneCommand, pickerCommand, sandboxCommand, switchCommand } from "./Sandbox/Cli";
 import { TaskCli } from "./Task/Cli";
 import { runCommand } from "./Agent/Cli";
 
 const command = Command.make("skipper").pipe(
   Command.withSubcommands([
     cloneCommand,
+    switchCommand,
     sandboxCommand,
     pickerCommand,
     runCommand,

--- a/src/Sandbox/Cli.ts
+++ b/src/Sandbox/Cli.ts
@@ -7,6 +7,8 @@ import { GitRepositoryOption } from "../domain/GitRepository";
 import { SandboxServiceImpl } from "./Service";
 import * as RepositoryPath from "../domain/RepositoryPath";
 import type { Option } from "effect";
+import { SwitchService, SwitchServiceImpl } from "@/internal/SwitchService";
+import { PickerCancelled } from "@/internal/InteractivePicker";
 
 type SandboxCommandConfig = {
   readonly type: "tmux-worktree" | "tmux-main" | "docker" | "ecs";
@@ -128,6 +130,29 @@ export const removeCommand = Command.make("remove", flags, (config) =>
 ).pipe(
   Command.withAlias("rm"),
   Command.withDescription("Remove sandbox resources")
+);
+
+export const switchCommand = Command.make(
+  "switch",
+  {
+    repository: flags.git.repository,
+    branch: flags.git.branch,
+  },
+  (input) =>
+    Effect.gen(function* () {
+      const service = yield* SwitchService;
+
+      yield* service.run(input);
+    }).pipe(
+      Effect.catchIf(
+        (error): error is PickerCancelled => error instanceof PickerCancelled,
+        () => Effect.void
+      ),
+      Effect.provide(SwitchServiceImpl)
+    )
+).pipe(
+  Command.withAlias("sw"),
+  Command.withDescription("Pick repo and branch, then switch tmux")
 );
 
 export const sandboxCommand = Command.make("sandbox").pipe(

--- a/src/internal/InteractivePicker.ts
+++ b/src/internal/InteractivePicker.ts
@@ -1,0 +1,216 @@
+import { Effect } from "effect";
+import { UnknownError } from "effect/Cause";
+import {
+  clearScreenDown,
+  cursorTo,
+  emitKeypressEvents,
+  moveCursor,
+} from "node:readline";
+
+export class PickerCancelled {
+  readonly _tag = "PickerCancelled";
+}
+
+export type PickerOption<T> = {
+  readonly label: string;
+  readonly value: T;
+};
+
+const MAX_VISIBLE_OPTIONS = 8;
+
+const normalize = (value: string) => value.trim().toLowerCase();
+
+const scoreOption = (query: string, label: string) => {
+  if (query.length === 0) {
+    return 0;
+  }
+
+  const normalizedLabel = normalize(label);
+
+  if (normalizedLabel.startsWith(query)) {
+    return 0;
+  }
+
+  const matchIndex = normalizedLabel.indexOf(query);
+  return matchIndex === -1 ? Number.POSITIVE_INFINITY : matchIndex + 1;
+};
+
+const filterOptions = <T>(
+  query: string,
+  options: ReadonlyArray<PickerOption<T>>
+): ReadonlyArray<PickerOption<T>> => {
+  if (query.length === 0) {
+    return options;
+  }
+
+  return [...options]
+    .map((option) => ({ option, score: scoreOption(query, option.label) }))
+    .filter((entry) => Number.isFinite(entry.score))
+    .sort((left, right) => {
+      if (left.score !== right.score) {
+        return left.score - right.score;
+      }
+
+      return left.option.label.localeCompare(right.option.label);
+    })
+    .map((entry) => entry.option);
+};
+
+const isPrintableKey = (value: string, ctrl: boolean, meta: boolean) =>
+  value.length === 1 && ctrl === false && meta === false;
+
+export const pickOne = <T>(
+  title: string,
+  options: ReadonlyArray<PickerOption<T>>
+) =>
+  Effect.tryPromise({
+    try: () =>
+      new Promise<T>((resolve, reject) => {
+        if (!process.stdin.isTTY || !process.stdout.isTTY) {
+          reject(new UnknownError(undefined, "Interactive picker requires a TTY"));
+          return;
+        }
+
+        if (options.length === 0) {
+          reject(new UnknownError(undefined, `No options available for ${title}`));
+          return;
+        }
+
+        emitKeypressEvents(process.stdin);
+        process.stdin.resume();
+        process.stdin.setRawMode?.(true);
+
+        let query = "";
+        let selectedIndex = 0;
+        let previousLineCount = 0;
+
+        const cleanup = () => {
+          process.stdin.setRawMode?.(false);
+          process.stdin.pause();
+          process.stdin.off("keypress", onKeypress);
+
+          if (previousLineCount > 0) {
+            moveCursor(process.stdout, 0, -(previousLineCount - 1));
+            cursorTo(process.stdout, 0);
+            clearScreenDown(process.stdout);
+          }
+
+          process.stdout.write("\x1b[?25h");
+        };
+
+        const getMatches = () => filterOptions(normalize(query), options);
+
+        const render = () => {
+          const matches = getMatches();
+          const clampedIndex = Math.max(
+            0,
+            Math.min(selectedIndex, Math.max(matches.length - 1, 0))
+          );
+
+          selectedIndex = clampedIndex;
+
+          const windowStart = Math.max(
+            0,
+            Math.min(
+              selectedIndex,
+              Math.max(matches.length - MAX_VISIBLE_OPTIONS, 0)
+            )
+          );
+          const visibleOptions = matches.slice(
+            windowStart,
+            windowStart + MAX_VISIBLE_OPTIONS
+          );
+          const lines = [
+            `${title}: ${query}`,
+            ...(visibleOptions.length === 0
+              ? ["  No matches"]
+              : visibleOptions.map((option, index) =>
+                  windowStart + index === selectedIndex
+                    ? `> ${option.label}`
+                    : `  ${option.label}`
+                )),
+          ];
+
+          process.stdout.write("\x1b[?25l");
+
+          if (previousLineCount > 0) {
+            moveCursor(process.stdout, 0, -(previousLineCount - 1));
+            cursorTo(process.stdout, 0);
+          }
+
+          clearScreenDown(process.stdout);
+          process.stdout.write(lines.join("\n"));
+          previousLineCount = lines.length;
+        };
+
+        const finish = (value: T) => {
+          cleanup();
+          process.stdout.write("\n");
+          resolve(value);
+        };
+
+        const cancel = () => {
+          cleanup();
+          process.stdout.write("\n");
+          reject(new PickerCancelled());
+        };
+
+        const onKeypress = (
+          value: string,
+          key: { name?: string; ctrl?: boolean; meta?: boolean }
+        ) => {
+          const matches = getMatches();
+
+          switch (key.name) {
+            case "up":
+              if (matches.length > 0) {
+                selectedIndex = Math.max(0, selectedIndex - 1);
+              }
+              render();
+              return;
+            case "down":
+              if (matches.length > 0) {
+                selectedIndex = Math.min(matches.length - 1, selectedIndex + 1);
+              }
+              render();
+              return;
+            case "backspace":
+              query = query.slice(0, -1);
+              selectedIndex = 0;
+              render();
+              return;
+            case "return": {
+              const selected = matches[selectedIndex];
+
+              if (selected !== undefined) {
+                finish(selected.value);
+              }
+              return;
+            }
+            case "escape":
+              cancel();
+              return;
+            default:
+              break;
+          }
+
+          if (key.ctrl === true && key.name === "c") {
+            cancel();
+            return;
+          }
+
+          if (isPrintableKey(value, key.ctrl === true, key.meta === true)) {
+            query += value;
+            selectedIndex = 0;
+            render();
+          }
+        };
+
+        process.stdin.on("keypress", onKeypress);
+        render();
+      }),
+    catch: (error) =>
+      error instanceof PickerCancelled || error instanceof UnknownError
+        ? error
+        : new UnknownError(error, `Failed to read ${title} selection`),
+  });

--- a/src/internal/SwitchService.test.ts
+++ b/src/internal/SwitchService.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, test } from "bun:test";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { Effect } from "effect";
+import {
+  listBranches,
+  listRepositories,
+  makeSessionName,
+  resolveTargetPath,
+} from "./SwitchService";
+
+describe("SwitchService", () => {
+  test("lists git repositories only", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skipper-switch-repo-"));
+
+    try {
+      await mkdir(join(root, "demo", ".git"), { recursive: true });
+      await mkdir(join(root, "notes"), { recursive: true });
+      await writeFile(join(root, "README.md"), "x\n");
+
+      const repositories = await Effect.runPromise(listRepositories(root));
+
+      expect(repositories).toEqual(["demo"]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("lists branches with main first", async () => {
+    const root = await mkdtemp(join(tmpdir(), "skipper-switch-branch-"));
+    const repositoryRoot = join(root, "repositories");
+    const workTreeRoot = join(root, "worktrees");
+
+    try {
+      await mkdir(join(repositoryRoot, "demo", ".git"), { recursive: true });
+      await mkdir(join(workTreeRoot, "demo", "feature-a"), { recursive: true });
+      await mkdir(join(workTreeRoot, "demo", "bugfix"), { recursive: true });
+
+      const branches = await Effect.runPromise(
+        listBranches("demo", { repositoryRoot, workTreeRoot })
+      );
+
+      expect(branches).toEqual(["main", "bugfix", "feature-a"]);
+    } finally {
+      await rm(root, { recursive: true, force: true });
+    }
+  });
+
+  test("resolveTargetPath uses repo root for main", () => {
+    expect(String(resolveTargetPath("demo", "main"))).toContain("/github/demo");
+    expect(String(resolveTargetPath("demo", "feature-a"))).toContain(
+      "/skipper/worktree/demo/feature-a"
+    );
+  });
+
+  test("makeSessionName sanitizes values", () => {
+    expect(makeSessionName("team/repo", "feat/test branch")).toBe(
+      "team-repo--feat-test-branch"
+    );
+  });
+
+  test("listRepositories returns empty when root missing", async () => {
+    const repositories = await Effect.runPromise(
+      listRepositories(join(tmpdir(), "skipper-switch-missing-root"))
+    );
+
+    expect(repositories).toEqual([]);
+  });
+});

--- a/src/internal/SwitchService.ts
+++ b/src/internal/SwitchService.ts
@@ -1,0 +1,247 @@
+import { access, readdir } from "node:fs/promises";
+import { join } from "node:path";
+import { Effect, Option, ServiceMap } from "effect";
+import { UnknownError } from "effect/Cause";
+import type { PlatformError } from "effect/PlatformError";
+import type { ChildProcessSpawner } from "effect/unstable/process/ChildProcessSpawner";
+import * as RepositoryPath from "@/domain/RepositoryPath";
+import * as WorkTreePath from "@/domain/WorkTreePath";
+import { pickOne, PickerCancelled } from "@/internal/InteractivePicker";
+import { TmuxService, TmuxServiceImpl } from "@/internal/TmuxService";
+
+const isInteractive = () =>
+  process.stdin.isTTY === true &&
+  process.stdout.isTTY === true &&
+  process.env.CI === undefined;
+
+const hasTerminal = () =>
+  process.stdin.isTTY === true && process.stdout.isTTY === true;
+
+const isNotFoundError = (error: unknown): error is NodeJS.ErrnoException =>
+  typeof error === "object" &&
+  error !== null &&
+  "code" in error &&
+  error.code === "ENOENT";
+
+const pathExists = async (path: string) => {
+  try {
+    await access(path);
+    return true;
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return false;
+    }
+
+    throw error;
+  }
+};
+
+const listDirectoryNames = async (path: string) => {
+  try {
+    const entries = await readdir(path, { withFileTypes: true });
+
+    return entries
+      .filter((entry) => entry.isDirectory())
+      .map((entry) => entry.name)
+      .sort((left, right) => left.localeCompare(right));
+  } catch (error) {
+    if (isNotFoundError(error)) {
+      return [];
+    }
+
+    throw error;
+  }
+};
+
+export const sortBranches = (branches: ReadonlyArray<string>) =>
+  [...new Set(branches)].sort((left, right) => {
+    if (left === "main") {
+      return -1;
+    }
+
+    if (right === "main") {
+      return 1;
+    }
+
+    return left.localeCompare(right);
+  });
+
+export const makeSessionName = (repository: string, branch: string) => {
+  const sanitize = (value: string) => {
+    const clean = value.replace(/[^a-zA-Z0-9_.-]+/g, "-").replace(/^-+|-+$/g, "");
+    return clean.length === 0 ? "default" : clean;
+  };
+
+  return `${sanitize(repository)}--${sanitize(branch)}`;
+};
+
+export const resolveTargetPath = (repository: string, branch: string) =>
+  branch === "main"
+    ? RepositoryPath.make(repository)
+    : WorkTreePath.make({ repository, branch });
+
+export const listRepositories = (root = RepositoryPath.root()) =>
+  Effect.tryPromise({
+    try: async () => {
+      const repositories = await listDirectoryNames(root);
+      const checks = await Promise.all(
+        repositories.map(async (repository) => ({
+          repository,
+          exists: await pathExists(join(root, repository, ".git")),
+        }))
+      );
+
+      return checks
+        .filter((entry) => entry.exists)
+        .map((entry) => entry.repository)
+        .sort((left, right) => left.localeCompare(right));
+    },
+    catch: (error) =>
+      new UnknownError(error, `Failed to list repositories in '${root}'`),
+  });
+
+export const listBranches = (
+  repository: string,
+  options?: {
+    readonly repositoryRoot?: string;
+    readonly workTreeRoot?: string;
+  }
+) =>
+  Effect.gen(function* () {
+    const repositoryRoot = options?.repositoryRoot ?? RepositoryPath.root();
+    const workTreeRoot = options?.workTreeRoot ?? WorkTreePath.root();
+    const repositoryPath = join(repositoryRoot, repository);
+    const repositoryExists = yield* Effect.tryPromise({
+      try: () => pathExists(repositoryPath),
+      catch: (error) =>
+        new UnknownError(error, `Failed to read repository '${repository}'`),
+    });
+
+    if (!repositoryExists) {
+      return yield* Effect.fail(
+        new UnknownError(
+          undefined,
+          `Repository '${repository}' not found in '${repositoryRoot}'`
+        )
+      );
+    }
+
+    const branches = yield* Effect.tryPromise({
+      try: () => listDirectoryNames(join(workTreeRoot, repository)),
+      catch: (error) =>
+        new UnknownError(error, `Failed to list branches for '${repository}'`),
+    });
+
+    return sortBranches(["main", ...branches]);
+  });
+
+const ensureInteractive = <A>(effect: Effect.Effect<A, UnknownError | PickerCancelled>) =>
+  isInteractive()
+    ? effect
+    : Effect.fail(
+        new UnknownError(
+          undefined,
+          "Switch requires a TTY when --repository or --branch is missing"
+        )
+      );
+
+const resolveRepository = (repository: string) =>
+  Effect.gen(function* () {
+    const repositories = yield* listRepositories();
+
+    if (!repositories.includes(repository)) {
+      return yield* Effect.fail(
+        new UnknownError(
+          undefined,
+          `Repository '${repository}' not found in '${RepositoryPath.root()}'`
+        )
+      );
+    }
+
+    return repository;
+  });
+
+const resolveBranch = (
+  repository: string,
+  branch: string,
+  availableBranches: ReadonlyArray<string>
+) =>
+  availableBranches.includes(branch)
+    ? Effect.succeed(branch)
+    : Effect.fail(
+        new UnknownError(
+          undefined,
+          `Branch '${branch}' not found for '${repository}'`
+        )
+      );
+
+const pickRepository = () =>
+  Effect.gen(function* () {
+    const repositories = yield* listRepositories();
+
+    if (repositories.length === 0) {
+      return yield* Effect.fail(
+        new UnknownError(
+          undefined,
+          `No repositories found in '${RepositoryPath.root()}'`
+        )
+      );
+    }
+
+    return yield* pickOne(
+      "Repository",
+      repositories.map((repository) => ({ label: repository, value: repository }))
+    );
+  });
+
+const pickBranch = (branches: ReadonlyArray<string>) =>
+  pickOne(
+    "Branch",
+    branches.map((branch) => ({ label: branch, value: branch }))
+  );
+
+export const SwitchService = ServiceMap.Service<{
+  run: (input: {
+    readonly repository: Option.Option<string>;
+    readonly branch: Option.Option<string>;
+  }) => Effect.Effect<void, PlatformError | UnknownError | PickerCancelled, ChildProcessSpawner>;
+}>("SwitchService");
+
+const run: (typeof SwitchService.Service)["run"] = (input) =>
+  Effect.gen(function* () {
+    if (!hasTerminal()) {
+      return yield* Effect.fail(
+        new UnknownError(undefined, "Switch requires an interactive terminal")
+      );
+    }
+
+    const repository = Option.isSome(input.repository)
+      ? yield* resolveRepository(input.repository.value)
+      : yield* ensureInteractive(pickRepository());
+    const branches = yield* listBranches(repository);
+    const branch = Option.isSome(input.branch)
+      ? yield* resolveBranch(repository, input.branch.value, branches)
+      : yield* ensureInteractive(pickBranch(branches));
+    const targetPath = resolveTargetPath(repository, branch);
+    const targetExists = yield* Effect.tryPromise({
+      try: () => pathExists(targetPath),
+      catch: (error) =>
+        new UnknownError(error, `Failed to resolve path for '${repository}:${branch}'`),
+    });
+
+    if (!targetExists) {
+      return yield* Effect.fail(
+        new UnknownError(
+          undefined,
+          `Target path '${targetPath}' not found for '${repository}:${branch}'`
+        )
+      );
+    }
+
+    const tmux = yield* TmuxService;
+    yield* tmux.attachSession(makeSessionName(repository, branch), targetPath);
+  }).pipe(Effect.provide(TmuxServiceImpl));
+
+export const SwitchServiceImpl = ServiceMap.make(SwitchService, {
+  run,
+});


### PR DESCRIPTION
## Summary
- add a top-level `switch` command for repo and branch selection instead of routing tmux switching through the sandbox picker
- keep filtering interactive with a small built-in picker and verify both direct terminal attach and in-tmux client switching
- include a changeset and focused tests for discovery, path resolution, and tmux switch flow